### PR TITLE
Remove `async` locks

### DIFF
--- a/behaviortree-rs/Cargo.toml
+++ b/behaviortree-rs/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.20"
 pretty_env_logger = "0.5.0"
 quick-xml = { version = "0.30.0", features = ["serde", "serialize"] }
 thiserror = "1.0.47"
-tokio = { version = "1.32.0", features = ["sync", "macros"] }
 
 [dev-dependencies]
+tokio = { version = "1.32.0", features = ["macros"] }
 tokio-test = "0.4.3"

--- a/behaviortree-rs/src/basic_types.rs
+++ b/behaviortree-rs/src/basic_types.rs
@@ -410,7 +410,6 @@ impl PortInfo {
     }
 
     pub fn set_default(&mut self, default: impl BTToString) {
-        // let test = <Box<dyn Any>>::downcast::<u32>(self.default_value().unwrap().bt_to_string()).unwrap();
         self.default_value = Some(default.bt_to_string())
     }
 

--- a/behaviortree-rs/src/blackboard.rs
+++ b/behaviortree-rs/src/blackboard.rs
@@ -1,7 +1,4 @@
-use std::{any::Any, collections::HashMap, sync::Arc};
-
-use futures::future::BoxFuture;
-use tokio::sync::{Mutex, RwLock};
+use std::{any::Any, collections::HashMap, sync::{Arc, Mutex, RwLock}};
 
 use crate::basic_types::{FromString, ParseStr};
 
@@ -61,14 +58,12 @@ where
 /// a `BlackboardPtr`.
 ///
 /// ```
-/// # tokio_test::block_on(async {
 /// use behaviortree_rs::Blackboard;
 ///
 /// // Create a root-level Blackboard
 /// let bb = Blackboard::create();
 /// // Create a child Blackboard
-/// let child = Blackboard::with_parent(&bb).await;
-/// # })
+/// let child = Blackboard::with_parent(&bb);
 /// ```
 ///
 /// Provides methods `get<T>()`, `get_exact<T>()`, and `set<T>()`.
@@ -125,15 +120,8 @@ impl Blackboard {
     }
 
     /// Creates a Blackboard with `parent_bb` as the parent. Returned as a new `BlackboardPtr`.
-    pub async fn with_parent(parent_bb: &Blackboard) -> Blackboard {
+    pub fn with_parent(parent_bb: &Blackboard) -> Blackboard {
         Self::new(Some(parent_bb.clone()))
-    }
-
-    /// Sync version of `with_parent()`
-    ///
-    /// Creates a Blackboard with `parent_bb` as the parent. Returned as a new `BlackboardPtr`.
-    pub fn with_parent_sync(parent_bb: &Blackboard) -> Blackboard {
-        crate::sync::block_on(Self::with_parent(parent_bb))
     }
 
     /// Creates a Blackboard with no parent and returns it as a `BlackboardPtr`.
@@ -151,82 +139,63 @@ impl Blackboard {
     /// Enables the Blackboard to use autoremapping when getting values from
     /// the parent Blackboard. Only uses autoremapping if there's no matching
     /// explicit remapping rule.
-    pub async fn enable_auto_remapping(&mut self, use_remapping: bool) {
-        self.data.write().await.auto_remapping = use_remapping;
-    }
-
-    /// Sync version of `enable_auto_remapping()`
-    ///
-    /// Enables the Blackboard to use autoremapping when getting values from
-    /// the parent Blackboard. Only uses autoremapping if there's no matching
-    /// explicit remapping rule.
-    pub fn enable_auto_remapping_sync(&mut self, use_remapping: bool) {
-        crate::sync::block_on(self.enable_auto_remapping(use_remapping))
+    pub fn enable_auto_remapping(&mut self, use_remapping: bool) {
+        self.data.write().unwrap().auto_remapping = use_remapping;
     }
 
     /// Adds remapping rule for Blackboard. Maps from `internal` (this Blackboard)
     /// to `external` (a parent Blackboard)
-    pub async fn add_subtree_remapping(&mut self, internal: String, external: String) {
+    pub fn add_subtree_remapping(&mut self, internal: String, external: String) {
         self.data
             .write()
-            .await
+            .unwrap()
             .internal_to_external
             .insert(internal, external);
     }
 
-    /// Sync version of add_subtree_remapping
-    ///
-    /// Adds remapping rule for Blackboard. Maps from `internal` (this Blackboard)
-    /// to `external` (a parent Blackboard)
-    pub fn add_subtree_remapping_sync(&mut self, internal: String, external: String) {
-        crate::sync::block_on(self.add_subtree_remapping(internal, external));
-    }
-
     /// Get an Rc to the Entry
-    fn get_entry<'a>(&'a mut self, key: &'a str) -> BoxFuture<Option<EntryPtr>> {
-        Box::pin(async move {
-            let mut blackboard = self.data.write().await;
+    fn get_entry<'a>(&'a mut self, key: &'a str) -> Option<EntryPtr> {
+        let mut blackboard = self.data.write().unwrap();
 
-            // Try to get the key
-            if let Some(entry) = blackboard.storage.get(key) {
-                return Some(Arc::clone(entry));
-            }
-            // Couldn't find key. Try remapping if we have a parent
-            else if let Some(parent_bb) = self.parent_bb.as_mut() {
-                if let Some(new_key) = blackboard.internal_to_external.get(key) {
-                    // Return the value of the parent's `get()`
-                    let parent_entry = parent_bb.get_entry(new_key).await;
+        // Try to get the key
+        if let Some(entry) = blackboard.storage.get(key) {
+            return Some(Arc::clone(entry));
+        }
+        // Couldn't find key. Try remapping if we have a parent
+        else if let Some(parent_bb) = self.parent_bb.as_mut() {
+            if let Some(new_key) = blackboard.internal_to_external.get(key) {
+                // Return the value of the parent's `get()`
+                let parent_entry = parent_bb.get_entry(new_key);
 
-                    if let Some(value) = &parent_entry {
-                        blackboard
-                            .storage
-                            .insert(key.to_string(), Arc::clone(value));
-                    }
-
-                    return parent_entry;
+                if let Some(value) = &parent_entry {
+                    blackboard
+                        .storage
+                        .insert(key.to_string(), Arc::clone(value));
                 }
-                // Use auto remapping
-                else if blackboard.auto_remapping {
-                    // Return the value of the parent's `get()`
-                    return parent_bb.get_entry(key).await;
-                }
-            }
 
-            // No matches
-            None
-        })
+                return parent_entry;
+            }
+            // Use auto remapping
+            else if blackboard.auto_remapping {
+                // Return the value of the parent's `get()`
+                return parent_bb.get_entry(key);
+            }
+        }
+
+        // No matches
+        None
     }
 
     /// Internal method that just tries to get value at key. If the stored
     /// type is not T, return None
-    async fn __get_no_string<T>(&mut self, key: &str) -> Option<T>
+    fn __get_no_string<T>(&mut self, key: &str) -> Option<T>
     where
         T: Any + Clone,
     {
         // Try to get the key
-        if let Some(entry) = self.get_entry(key).await {
+        if let Some(entry) = self.get_entry(key) {
             // Try to downcast directly to T
-            if let Some(value) = entry.lock().await.value.downcast_ref::<T>() {
+            if let Some(value) = entry.lock().unwrap().value.downcast_ref::<T>() {
                 return Some(value.clone());
             }
         }
@@ -236,14 +205,14 @@ impl Blackboard {
 
     /// Internal method that tries to get the value at key, but only works
     /// if it's a String/&str, then tries FromString to convert it to T
-    async fn __get_allow_string<T>(&mut self, key: &str) -> Option<T>
+    fn __get_allow_string<T>(&mut self, key: &str) -> Option<T>
     where
         T: Any + Clone + FromString + Send,
     {
         // Try to get the key
-        if let Some(entry) = self.get_entry(key).await {
+        if let Some(entry) = self.get_entry(key) {
             let value = {
-                let entry_lock = entry.lock().await;
+                let entry_lock = entry.lock().unwrap();
                 // If value is a String or &str, try to call `FromString` to convert to T
                 if let Some(value) = entry_lock.value.downcast_ref::<String>() {
                     value.to_string()
@@ -259,7 +228,7 @@ impl Blackboard {
             // Try to parse String into T
             if let Ok(value) = <String as ParseStr<T>>::parse_str(&value) {
                 // Update value with the value type instead of just a string
-                let mut t = entry.lock().await;
+                let mut t = entry.lock().unwrap();
                 t.value = Box::new(value.clone());
                 return Some(value);
             }
@@ -298,80 +267,25 @@ impl Blackboard {
     /// # Examples
     ///
     /// ```
-    /// # tokio_test::block_on(async {
     /// use behaviortree_rs::blackboard::Blackboard;
     ///
     /// let mut blackboard = Blackboard::create();
     ///
-    /// blackboard.set("foo", 132u32).await;
-    /// assert_eq!(blackboard.get::<u32>("foo").await, Some(132u32));
+    /// blackboard.set("foo", 132u32);
+    /// assert_eq!(blackboard.get::<u32>("foo"), Some(132u32));
     ///
-    /// blackboard.set("bar", "100").await;
+    /// blackboard.set("bar", "100");
     ///
-    /// assert_eq!(blackboard.get::<String>("bar").await, Some(String::from("100")));
-    /// assert_eq!(blackboard.get::<u32>("bar").await, Some(100u32));
-    /// # })
+    /// assert_eq!(blackboard.get::<String>("bar"), Some(String::from("100")));
+    /// assert_eq!(blackboard.get::<u32>("bar"), Some(100u32));
     /// ```
-    pub async fn get<T>(&mut self, key: impl AsRef<str>) -> Option<T>
+    pub fn get<T>(&mut self, key: impl AsRef<str>) -> Option<T>
     where
         T: Any + Clone + FromString + Send,
     {
         // Try without parsing string first, then try with parsing string
         self.__get_no_string(key.as_ref())
-            .await
-            .or(self.__get_allow_string(key.as_ref()).await)
-    }
-
-    /// Sync version of `get<T>`
-    ///
-    /// Tries to return the value at `key`. The type `T` must implement
-    /// `FromString` when calling this method; it will try to convert
-    /// from `String`/`&str` if there's an entry at `key` but it is not
-    /// of type `T`. If it does convert it successfully, it will replace
-    /// the existing value with `T` so converting from the string type
-    /// won't be needed next time.
-    ///
-    /// If you want to get an entry that has a type that doesn't implement
-    /// `FromString`, use `get_exact<T>` instead.
-    ///
-    /// The `Blackboard` tries a few things when reading a `key`:
-    /// - First it checks if it can find `key`:
-    ///     - Check itself for `key`
-    ///     - If it doesn't exist, if`self` has a parent `Blackboard`, it checks for key remapping
-    ///         - If a remapping rule exists for `key`, use the remapped `key`
-    ///         - If `auto_remapping` is enabled, it uses `key` directly
-    ///     - Return `None` if none of the above work
-    /// - If a value is matched, attempt to coerce the value to `T`. If it couldn't
-    /// be coerced to `T`:
-    ///     - If it's a `String` or `&str`, try calling `parse_str()`
-    /// - If none of those work, return `None`
-    ///
-    /// __NOTE__: This method borrows `self` mutably because if it finds a remapped
-    /// key from the parent `Blackboard`, it stores the `EntryPtr` in `self` so
-    /// the next lookup for it is quicker.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # tokio_test::block_on(async {
-    /// use behaviortree_rs::blackboard::Blackboard;
-    ///
-    /// let mut blackboard = Blackboard::create();
-    ///
-    /// blackboard.set("foo", 132u32).await;
-    /// assert_eq!(blackboard.get::<u32>("foo").await, Some(132u32));
-    ///
-    /// blackboard.set("bar", "100").await;
-    ///
-    /// assert_eq!(blackboard.get::<String>("bar").await, Some(String::from("100")));
-    /// assert_eq!(blackboard.get::<u32>("bar").await, Some(100u32));
-    /// # })
-    /// ```
-    pub fn get_sync<T>(&mut self, key: impl AsRef<str>) -> Option<T>
-    where
-        T: Any + Clone + FromString + Send,
-    {
-        futures::executor::block_on(self.get(key))
+            .or(self.__get_allow_string(key.as_ref()))
     }
 
     /// Version of `get<T>` that does _not_ try to convert from string if the type
@@ -383,59 +297,24 @@ impl Blackboard {
     /// # Examples
     ///
     /// ```
-    /// # tokio_test::block_on(async {
     /// use behaviortree_rs::blackboard::Blackboard;
     ///
     /// let mut blackboard = Blackboard::create();
     ///
-    /// blackboard.set("foo", 132u32).await;
-    /// assert_eq!(blackboard.get_exact::<u32>("foo").await, Some(132u32));
+    /// blackboard.set("foo", 132u32);
+    /// assert_eq!(blackboard.get_exact::<u32>("foo"), Some(132u32));
     ///
-    /// blackboard.set("bar", "100").await;
+    /// blackboard.set("bar", "100");
     ///
-    /// assert_eq!(blackboard.get_exact::<&str>("bar").await, Some("100"));
-    /// assert_eq!(blackboard.get_exact::<String>("bar").await, None);
-    /// assert_eq!(blackboard.get_exact::<u32>("bar").await, None);
-    /// # })
+    /// assert_eq!(blackboard.get_exact::<&str>("bar"), Some("100"));
+    /// assert_eq!(blackboard.get_exact::<String>("bar"), None);
+    /// assert_eq!(blackboard.get_exact::<u32>("bar"), None);
     /// ```
-    pub async fn get_exact<T>(&mut self, key: impl AsRef<str>) -> Option<T>
+    pub fn get_exact<T>(&mut self, key: impl AsRef<str>) -> Option<T>
     where
         T: Any + Clone,
     {
-        self.__get_no_string(key.as_ref()).await
-    }
-
-    /// Sync version of `get_exact<T>`
-    ///
-    /// Version of `get<T>` that does _not_ try to convert from string if the type
-    /// doesn't match. This method has the benefit of not requiring the trait
-    /// `FromString`, which allows you to avoid implementing the trait for
-    /// types that don't need it or it's impossible to represent the data
-    /// type as a string.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # tokio_test::block_on(async {
-    /// use behaviortree_rs::blackboard::Blackboard;
-    ///
-    /// let mut blackboard = Blackboard::create();
-    ///
-    /// blackboard.set_sync("foo", 132u32);
-    /// assert_eq!(blackboard.get_exact_sync::<u32>("foo"), Some(132u32));
-    ///
-    /// blackboard.set_sync("bar", "100");
-    ///
-    /// assert_eq!(blackboard.get_exact_sync::<&str>("bar"), Some("100"));
-    /// assert_eq!(blackboard.get_exact_sync::<String>("bar"), None);
-    /// assert_eq!(blackboard.get_exact_sync::<u32>("bar"), None);
-    /// # })
-    /// ```
-    pub fn get_exact_sync<T>(&mut self, key: impl AsRef<str>) -> Option<T>
-    where
-        T: Any + Clone,
-    {
-        futures::executor::block_on(self.get_exact(key))
+        self.__get_no_string(key.as_ref())
     }
 
     /// Sets the `value` in the Blackboard at `key`.
@@ -443,101 +322,71 @@ impl Blackboard {
     /// # Examples
     ///
     /// ```
-    /// # tokio_test::block_on(async {
     /// use behaviortree_rs::blackboard::Blackboard;
     ///
     /// let mut blackboard = Blackboard::create();
     ///
-    /// blackboard.set("foo", 132u32).await;
-    /// assert_eq!(blackboard.get::<u32>("foo").await, Some(132u32));
+    /// blackboard.set("foo", 132u32);
+    /// assert_eq!(blackboard.get::<u32>("foo"), Some(132u32));
     ///
-    /// blackboard.set("bar", "100").await;
+    /// blackboard.set("bar", "100");
     ///
-    /// assert_eq!(blackboard.get::<String>("bar").await, Some(String::from("100")));
-    /// assert_eq!(blackboard.get::<u32>("bar").await, Some(100u32));
-    /// # })
+    /// assert_eq!(blackboard.get::<String>("bar"), Some(String::from("100")));
+    /// assert_eq!(blackboard.get::<u32>("bar"), Some(100u32));
     /// ```
-    pub async fn set<T: Any + Send + 'static>(&mut self, key: impl AsRef<str>, value: T) {
+    pub fn set<T: Any + Send + 'static>(&mut self, key: impl AsRef<str>, value: T) {
         let key = key.as_ref().to_string();
 
-        let mut blackboard = self.data.write().await;
+        let mut blackboard = self.data.write().unwrap();
 
         if let Some(entry) = blackboard.storage.get_mut(&key) {
-            entry.lock().await.value = Box::new(value);
+            entry.lock().unwrap().value = Box::new(value);
         } else {
             drop(blackboard);
-            let entry = self.create_entry(&key).await;
+            let entry = self.create_entry(&key);
 
             // Set value of new entry
-            entry.lock().await.value = Box::new(value);
+            entry.lock().unwrap().value = Box::new(value);
         }
     }
 
-    /// Sync version of `set<T>`
-    ///
-    /// Sets the `value` in the Blackboard at `key`.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # tokio_test::block_on(async {
-    /// use behaviortree_rs::blackboard::Blackboard;
-    ///
-    /// let mut blackboard = Blackboard::create();
-    ///
-    /// blackboard.set_sync("foo", 132u32);
-    /// assert_eq!(blackboard.get_sync::<u32>("foo"), Some(132u32));
-    ///
-    /// blackboard.set_sync("bar", "100");
-    ///
-    /// assert_eq!(blackboard.get_sync::<String>("bar"), Some(String::from("100")));
-    /// assert_eq!(blackboard.get_sync::<u32>("bar"), Some(100u32));
-    /// # })
-    /// ```
-    pub fn set_sync<T: Any + Send + 'static>(&mut self, key: impl AsRef<str>, value: T) {
-        futures::executor::block_on(self.set(key, value))
-    }
+    fn create_entry<'a>(&'a mut self, key: &'a (impl AsRef<str> + Sync)) -> EntryPtr {
+        let entry;
 
-    fn create_entry<'a>(&'a mut self, key: &'a (impl AsRef<str> + Sync)) -> BoxFuture<EntryPtr> {
-        Box::pin(async move {
-            let entry;
+        let mut blackboard = self.data.write().unwrap();
 
-            let mut blackboard = self.data.write().await;
+        // If the entry already exists
+        if let Some(existing_entry) = blackboard.storage.get(key.as_ref()) {
+            return Arc::clone(existing_entry);
+        }
+        // Use explicit remapping rule
+        else if blackboard.internal_to_external.contains_key(key.as_ref())
+            && self.parent_bb.is_some()
+        {
+            // Safe to unwrap because .contains_key() is true
+            let remapped_key = blackboard.internal_to_external.get(key.as_ref()).unwrap();
 
-            // If the entry already exists
-            if let Some(existing_entry) = blackboard.storage.get(key.as_ref()) {
-                return Arc::clone(existing_entry);
-            }
-            // Use explicit remapping rule
-            else if blackboard.internal_to_external.contains_key(key.as_ref())
-                && self.parent_bb.is_some()
-            {
-                // Safe to unwrap because .contains_key() is true
-                let remapped_key = blackboard.internal_to_external.get(key.as_ref()).unwrap();
+            entry = (*self.parent_bb)
+                .as_mut()
+                .unwrap()
+                .create_entry(remapped_key);
+        }
+        // Use autoremapping
+        else if blackboard.auto_remapping && self.parent_bb.is_some() {
+            entry = (*self.parent_bb).as_mut().unwrap().create_entry(key);
+        }
+        // No remapping or no parent blackboard
+        else {
+            // Create an entry with an empty placeholder value
+            entry = Arc::new(Mutex::new(Entry {
+                value: Box::new(()),
+            }));
+        }
 
-                entry = (*self.parent_bb)
-                    .as_mut()
-                    .unwrap()
-                    .create_entry(remapped_key)
-                    .await;
-            }
-            // Use autoremapping
-            else if blackboard.auto_remapping && self.parent_bb.is_some() {
-                entry = (*self.parent_bb).as_mut().unwrap().create_entry(key).await;
-            }
-            // No remapping or no parent blackboard
-            else {
-                // Create an entry with an empty placeholder value
-                entry = Arc::new(Mutex::new(Entry {
-                    value: Box::new(()),
-                }));
-            }
-
-            blackboard
-                .storage
-                .insert(key.as_ref().to_string(), Arc::clone(&entry));
-            entry
-        })
+        blackboard
+            .storage
+            .insert(key.as_ref().to_string(), Arc::clone(&entry));
+        entry
     }
 }
 
@@ -552,113 +401,112 @@ mod tests {
         // With no remapping
 
         let mut root_bb = Blackboard::create();
-        let mut left_bb = Blackboard::with_parent(&root_bb).await;
-        let mut right_bb = Blackboard::with_parent(&root_bb).await;
+        let mut left_bb = Blackboard::with_parent(&root_bb);
+        let mut right_bb = Blackboard::with_parent(&root_bb);
 
-        left_bb.set("foo", 123u32).await;
+        left_bb.set("foo", 123u32);
 
-        assert!(left_bb.get::<u32>("foo").await.is_some());
+        assert!(left_bb.get::<u32>("foo").is_some());
         // These two should be none because remapping is not enabled
-        assert!(right_bb.get::<u32>("foo").await.is_none());
-        assert!(root_bb.get::<u32>("foo").await.is_none());
+        assert!(right_bb.get::<u32>("foo").is_none());
+        assert!(root_bb.get::<u32>("foo").is_none());
 
         // With autoremapping
 
         let mut root_bb = Blackboard::create();
-        let mut left_bb = Blackboard::with_parent(&root_bb).await;
-        let mut right_bb = Blackboard::with_parent(&root_bb).await;
+        let mut left_bb = Blackboard::with_parent(&root_bb);
+        let mut right_bb = Blackboard::with_parent(&root_bb);
 
-        root_bb.enable_auto_remapping(true).await;
-        left_bb.enable_auto_remapping(true).await;
-        right_bb.enable_auto_remapping(true).await;
+        root_bb.enable_auto_remapping(true);
+        left_bb.enable_auto_remapping(true);
+        right_bb.enable_auto_remapping(true);
 
-        left_bb.set("foo", 123u32).await;
+        left_bb.set("foo", 123u32);
 
-        assert_eq!(left_bb.get::<u32>("foo").await, Some(123));
-        assert_eq!(right_bb.get::<u32>("foo").await, Some(123));
-        assert_eq!(root_bb.get::<u32>("foo").await, Some(123));
+        assert_eq!(left_bb.get::<u32>("foo"), Some(123));
+        assert_eq!(right_bb.get::<u32>("foo"), Some(123));
+        assert_eq!(root_bb.get::<u32>("foo"), Some(123));
 
         // With custom remapping
         let mut root_bb = Blackboard::create();
-        let mut left_bb = Blackboard::with_parent(&root_bb).await;
-        let mut right_bb = Blackboard::with_parent(&root_bb).await;
+        let mut left_bb = Blackboard::with_parent(&root_bb);
+        let mut right_bb = Blackboard::with_parent(&root_bb);
 
         right_bb
             .add_subtree_remapping(String::from("foo"), String::from("bar"))
-            .await;
+            ;
         left_bb
             .add_subtree_remapping(String::from("foo"), String::from("bar"))
-            .await;
+            ;
 
-        left_bb.set("foo", 123u32).await;
+        left_bb.set("foo", 123u32);
 
-        assert_eq!(left_bb.get::<u32>("foo").await, Some(123));
-        assert_eq!(right_bb.get::<u32>("foo").await, Some(123));
-        assert_eq!(root_bb.get::<u32>("bar").await, Some(123));
+        assert_eq!(left_bb.get::<u32>("foo"), Some(123));
+        assert_eq!(right_bb.get::<u32>("foo"), Some(123));
+        assert_eq!(root_bb.get::<u32>("bar"), Some(123));
     }
 
-    #[tokio::test]
-    async fn remapping() {
+    fn remapping() {
         // No remapping
 
         let mut root_bb = Blackboard::create();
-        let mut child_bb = Blackboard::with_parent(&root_bb).await;
+        let mut child_bb = Blackboard::with_parent(&root_bb);
 
-        root_bb.set("foo", 123u32).await;
+        root_bb.set("foo", 123u32);
 
-        assert!(child_bb.get::<u32>("foo").await.is_none());
+        assert!(child_bb.get::<u32>("foo").is_none());
 
         // Auto remapping
 
         let mut root_bb = Blackboard::create();
-        let mut child1_bb = Blackboard::with_parent(&root_bb).await;
-        let mut child2_bb = Blackboard::with_parent(&child1_bb).await;
-        let mut child3_bb = Blackboard::with_parent(&child2_bb).await;
+        let mut child1_bb = Blackboard::with_parent(&root_bb);
+        let mut child2_bb = Blackboard::with_parent(&child1_bb);
+        let mut child3_bb = Blackboard::with_parent(&child2_bb);
 
-        child1_bb.enable_auto_remapping(true).await;
-        child2_bb.enable_auto_remapping(true).await;
-        child3_bb.enable_auto_remapping(true).await;
+        child1_bb.enable_auto_remapping(true);
+        child2_bb.enable_auto_remapping(true);
+        child3_bb.enable_auto_remapping(true);
 
-        root_bb.set("foo", 123u32).await;
+        root_bb.set("foo", 123u32);
 
-        assert_eq!(child1_bb.get::<u32>("foo").await, Some(123));
-        assert_eq!(child2_bb.get::<u32>("foo").await, Some(123));
-        assert_eq!(child3_bb.get::<u32>("foo").await, Some(123));
+        assert_eq!(child1_bb.get::<u32>("foo"), Some(123));
+        assert_eq!(child2_bb.get::<u32>("foo"), Some(123));
+        assert_eq!(child3_bb.get::<u32>("foo"), Some(123));
 
         // Custom remapping
 
         let mut root_bb = Blackboard::create();
-        let mut child1_bb = Blackboard::with_parent(&root_bb).await;
-        let mut child2_bb = Blackboard::with_parent(&child1_bb).await;
-        let mut child3_bb = Blackboard::with_parent(&child2_bb).await;
+        let mut child1_bb = Blackboard::with_parent(&root_bb);
+        let mut child2_bb = Blackboard::with_parent(&child1_bb);
+        let mut child3_bb = Blackboard::with_parent(&child2_bb);
 
         child1_bb
             .add_subtree_remapping(String::from("child1"), String::from("root"))
-            .await;
+            ;
         child2_bb
             .add_subtree_remapping(String::from("child2"), String::from("child1"))
-            .await;
+            ;
         child3_bb
             .add_subtree_remapping(String::from("child3"), String::from("child2"))
-            .await;
+            ;
 
-        root_bb.set("root", 123u32).await;
+        root_bb.set("root", 123u32);
 
-        assert_eq!(child1_bb.get::<u32>("child1").await, Some(123));
-        assert_eq!(child2_bb.get::<u32>("child2").await, Some(123));
-        assert_eq!(child3_bb.get::<u32>("child3").await, Some(123));
-        assert_eq!(child3_bb.get::<u32>("foo").await, None);
+        assert_eq!(child1_bb.get::<u32>("child1"), Some(123));
+        assert_eq!(child2_bb.get::<u32>("child2"), Some(123));
+        assert_eq!(child3_bb.get::<u32>("child3"), Some(123));
+        assert_eq!(child3_bb.get::<u32>("foo"), None);
     }
 
     #[tokio::test]
     async fn type_matching() {
         let mut bb = Blackboard::create();
 
-        bb.set("foo", 123u32).await;
+        bb.set("foo", 123u32);
 
-        assert!(bb.get::<u32>("foo").await.is_some());
-        assert!(bb.get::<String>("foo").await.is_none());
-        assert!(bb.get::<f32>("foo").await.is_none());
+        assert!(bb.get::<u32>("foo").is_some());
+        assert!(bb.get::<String>("foo").is_none());
+        assert!(bb.get::<f32>("foo").is_none());
     }
 
     #[tokio::test]
@@ -694,23 +542,23 @@ mod tests {
             bar: String::from("bar"),
         };
 
-        bb.set("custom", custom_value.clone()).await;
-        bb.set("custom_str", String::from("123,bar")).await;
+        bb.set("custom", custom_value.clone());
+        bb.set("custom_str", String::from("123,bar"));
         bb.set("custom_str_malformed", String::from("not an int,bar"))
-            .await;
+            ;
 
         assert_eq!(
-            bb.get_exact::<CustomEntry>("custom").await.as_ref(),
+            bb.get_exact::<CustomEntry>("custom").as_ref(),
             Some(&custom_value)
         );
         // Check parse from String
         assert_eq!(
-            bb.get::<CustomEntry>("custom_str").await.as_ref(),
+            bb.get::<CustomEntry>("custom_str").as_ref(),
             Some(&custom_value)
         );
         // Check it returns None if it cannot be parsed
         assert_eq!(
-            bb.get::<CustomEntry>("custom_str_malformed").await.as_ref(),
+            bb.get::<CustomEntry>("custom_str_malformed").as_ref(),
             None
         );
     }

--- a/behaviortree-rs/src/blackboard.rs
+++ b/behaviortree-rs/src/blackboard.rs
@@ -396,6 +396,7 @@ mod tests {
 
     // TODO: add other tests
 
+    #[test]
     fn create_entry() {
         // With no remapping
 
@@ -445,6 +446,7 @@ mod tests {
         assert_eq!(root_bb.get::<u32>("bar"), Some(123));
     }
 
+    #[test]
     fn remapping() {
         // No remapping
 
@@ -497,6 +499,7 @@ mod tests {
         assert_eq!(child3_bb.get::<u32>("foo"), None);
     }
 
+    #[test]
     fn type_matching() {
         let mut bb = Blackboard::create();
 
@@ -507,6 +510,7 @@ mod tests {
         assert!(bb.get::<f32>("foo").is_none());
     }
 
+    #[test]
     fn custom_type() {
         #[derive(Clone, Debug, PartialEq)]
         struct CustomEntry {

--- a/behaviortree-rs/src/blackboard.rs
+++ b/behaviortree-rs/src/blackboard.rs
@@ -396,8 +396,7 @@ mod tests {
 
     // TODO: add other tests
 
-    #[tokio::test]
-    async fn create_entry() {
+    fn create_entry() {
         // With no remapping
 
         let mut root_bb = Blackboard::create();
@@ -498,8 +497,7 @@ mod tests {
         assert_eq!(child3_bb.get::<u32>("foo"), None);
     }
 
-    #[tokio::test]
-    async fn type_matching() {
+    fn type_matching() {
         let mut bb = Blackboard::create();
 
         bb.set("foo", 123u32);
@@ -509,8 +507,7 @@ mod tests {
         assert!(bb.get::<f32>("foo").is_none());
     }
 
-    #[tokio::test]
-    async fn custom_type() {
+    fn custom_type() {
         #[derive(Clone, Debug, PartialEq)]
         struct CustomEntry {
             pub foo: u32,

--- a/behaviortree-rs/src/lib.rs
+++ b/behaviortree-rs/src/lib.rs
@@ -242,11 +242,7 @@ pub use nodes::NodeResult;
 pub use tree::Factory;
 
 extern crate futures as futures_internal;
-extern crate tokio as tokio_internal;
 
 pub mod sync {
     pub use futures::{executor::block_on, future::BoxFuture};
-
-    pub use tokio::sync::Mutex;
-    pub use tokio::task::spawn_blocking;
 }

--- a/behaviortree-rs/src/nodes/control/parallel.rs
+++ b/behaviortree-rs/src/nodes/control/parallel.rs
@@ -69,8 +69,8 @@ impl ParallelNode {
 impl AsyncTick for ParallelNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
-            self.success_threshold = self.config_mut().get_input("success_count").await.unwrap();
-            self.failure_threshold = self.config_mut().get_input("failure_count").await.unwrap();
+            self.success_threshold = self.config_mut().get_input("success_count").unwrap();
+            self.failure_threshold = self.config_mut().get_input("failure_count").unwrap();
 
             let children_count = self.children.len();
 

--- a/behaviortree-rs/src/nodes/control/parallel_all.rs
+++ b/behaviortree-rs/src/nodes/control/parallel_all.rs
@@ -45,7 +45,7 @@ impl ParallelAllNode {
 impl AsyncTick for ParallelAllNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
-            self.failure_threshold = self.config_mut().get_input("max_failures").await?;
+            self.failure_threshold = self.config_mut().get_input("max_failures")?;
 
             let children_count = self.children.len();
 

--- a/behaviortree-rs/src/nodes/decorator/repeat.rs
+++ b/behaviortree-rs/src/nodes/decorator/repeat.rs
@@ -38,7 +38,7 @@ impl AsyncTick for RepeatNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             // Load num_cycles from the port value
-            self.num_cycles = self.config.get_input("num_cycles").await?;
+            self.num_cycles = self.config.get_input("num_cycles")?;
 
             let mut do_loop = (self.repeat_count as i32) < self.num_cycles || self.num_cycles == -1;
 

--- a/behaviortree-rs/src/nodes/decorator/retry.rs
+++ b/behaviortree-rs/src/nodes/decorator/retry.rs
@@ -38,7 +38,7 @@ impl AsyncTick for RetryNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             // Load num_cycles from the port value
-            self.max_attempts = self.config.get_input("num_attempts").await?;
+            self.max_attempts = self.config.get_input("num_attempts")?;
 
             let mut do_loop =
                 (self.try_count as i32) < self.max_attempts || self.max_attempts == -1;

--- a/behaviortree-rs/src/nodes/decorator/run_once.rs
+++ b/behaviortree-rs/src/nodes/decorator/run_once.rs
@@ -27,7 +27,7 @@ pub struct RunOnceNode {
 impl AsyncTick for RunOnceNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
-            let skip = self.config.get_input("then_skip").await?;
+            let skip = self.config.get_input("then_skip")?;
 
             if self.already_ticked {
                 return if skip {

--- a/behaviortree-rs/src/tree.rs
+++ b/behaviortree-rs/src/tree.rs
@@ -18,7 +18,7 @@ use crate::{
     macros::build_node_ptr,
     nodes::{
         self, AsyncHalt, NodeConfig,
-        NodeResult, TreeNodeBase, TreeNodePtr,
+        NodeResult, TreeNodePtr,
     },
 };
 
@@ -493,7 +493,7 @@ impl Factory {
                     let node = match node_name.as_str() {
                         "SubTree" => {
                             let attributes = attributes.to_map()?;
-                            let mut child_blackboard = Blackboard::with_parent(blackboard).await;
+                            let mut child_blackboard = Blackboard::with_parent(blackboard);
 
                             // Process attributes (Ports, special fields, etc)
                             for (attr, value) in attributes.iter() {
@@ -502,8 +502,7 @@ impl Factory {
                                     child_blackboard
                                         .enable_auto_remapping(<bool as FromString>::from_string(
                                             value,
-                                        )?)
-                                        .await;
+                                        )?);
                                     continue;
                                 } else if !attr.is_allowed_port_name() {
                                     continue;
@@ -512,11 +511,10 @@ impl Factory {
                                 if let Some(port_name) = value.strip_bb_pointer() {
                                     // Add remapping if `value` is a Blackboard pointer
                                     child_blackboard
-                                        .add_subtree_remapping(attr.clone(), port_name)
-                                        .await;
+                                        .add_subtree_remapping(attr.clone(), port_name);
                                 } else {
                                     // Set string value into Blackboard
-                                    child_blackboard.set(attr, value.clone()).await;
+                                    child_blackboard.set(attr, value.clone());
                                 }
                             }
 

--- a/behaviortree-rs/tests/nodes.rs
+++ b/behaviortree-rs/tests/nodes.rs
@@ -20,7 +20,7 @@ pub struct StatusNode {}
 impl AsyncTick for StatusNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
-            let status: NodeStatus = self.config.get_input("status").await?;
+            let status: NodeStatus = self.config.get_input("status")?;
 
             info!("I am a node that returns {}!", status.bt_to_string());
 
@@ -46,7 +46,7 @@ pub struct SuccessThenFailure {
 impl AsyncTick for SuccessThenFailure {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
-            let max_iters: usize = self.config.get_input("iters").await?;
+            let max_iters: usize = self.config.get_input("iters")?;
 
             info!("SuccessThenFailure!");
 
@@ -74,7 +74,7 @@ pub struct EchoNode {}
 impl AsyncTick for EchoNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
-            let msg: String = self.config.get_input("msg").await?;
+            let msg: String = self.config.get_input("msg")?;
 
             info!("{msg}");
 
@@ -117,14 +117,14 @@ impl AsyncStatefulActionNode for RunForNode {
 
     fn on_running(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
-            let limit: usize = self.config.get_input("iters").await?;
+            let limit: usize = self.config.get_input("iters")?;
 
             if self.counter < limit {
                 info!("RunFor {}", self.counter);
                 self.counter += 1;
                 Ok(NodeStatus::Running)
             } else {
-                Ok(self.config.get_input("status").await?)
+                Ok(self.config.get_input("status")?)
             }
         })
     }


### PR DESCRIPTION
# Changes

* Swaps all `tokio::sync::*` with `std::sync` equivalents.
* Remove all "sync" equivalents of `async` methods on `Blackboard`.