### PR TITLE
Change attribute macro to point to methods instead of requiring manually implemented traits

### DIFF
--- a/behaviortree-rs-derive/src/lib.rs
+++ b/behaviortree-rs-derive/src/lib.rs
@@ -4,7 +4,7 @@ use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::ToTokens;
 use syn::{
-    parse::{Parse, Parser}, punctuated::Punctuated, token::Comma, AttrStyle, DeriveInput, ItemStruct, LitStr
+    parse::{Parse, Parser}, punctuated::Punctuated, token::Comma, AttrStyle, DeriveInput, ItemStruct
 };
 
 #[macro_use]

--- a/behaviortree-rs/Cargo.toml
+++ b/behaviortree-rs/Cargo.toml
@@ -11,7 +11,8 @@ license = "MIT"
 
 [dependencies]
 anyhow = "1.0.75"
-behaviortree-rs-derive = "0.2.1"
+behaviortree-rs-derive = { path = "../behaviortree-rs-derive" }
+# behaviortree-rs-derive = "0.2.1"
 futures = { version = "0.3.28" }
 log = "0.4.20"
 pretty_env_logger = "0.5.0"

--- a/behaviortree-rs/src/blackboard.rs
+++ b/behaviortree-rs/src/blackboard.rs
@@ -1,4 +1,8 @@
-use std::{any::Any, collections::HashMap, sync::{Arc, Mutex, RwLock}};
+use std::{
+    any::Any,
+    collections::HashMap,
+    sync::{Arc, Mutex, RwLock},
+};
 
 use crate::basic_types::{FromString, ParseStr};
 
@@ -432,12 +436,8 @@ mod tests {
         let mut left_bb = Blackboard::with_parent(&root_bb);
         let mut right_bb = Blackboard::with_parent(&root_bb);
 
-        right_bb
-            .add_subtree_remapping(String::from("foo"), String::from("bar"))
-            ;
-        left_bb
-            .add_subtree_remapping(String::from("foo"), String::from("bar"))
-            ;
+        right_bb.add_subtree_remapping(String::from("foo"), String::from("bar"));
+        left_bb.add_subtree_remapping(String::from("foo"), String::from("bar"));
 
         left_bb.set("foo", 123u32);
 
@@ -481,15 +481,9 @@ mod tests {
         let mut child2_bb = Blackboard::with_parent(&child1_bb);
         let mut child3_bb = Blackboard::with_parent(&child2_bb);
 
-        child1_bb
-            .add_subtree_remapping(String::from("child1"), String::from("root"))
-            ;
-        child2_bb
-            .add_subtree_remapping(String::from("child2"), String::from("child1"))
-            ;
-        child3_bb
-            .add_subtree_remapping(String::from("child3"), String::from("child2"))
-            ;
+        child1_bb.add_subtree_remapping(String::from("child1"), String::from("root"));
+        child2_bb.add_subtree_remapping(String::from("child2"), String::from("child1"));
+        child3_bb.add_subtree_remapping(String::from("child3"), String::from("child2"));
 
         root_bb.set("root", 123u32);
 
@@ -545,8 +539,7 @@ mod tests {
 
         bb.set("custom", custom_value.clone());
         bb.set("custom_str", String::from("123,bar"));
-        bb.set("custom_str_malformed", String::from("not an int,bar"))
-            ;
+        bb.set("custom_str_malformed", String::from("not an int,bar"));
 
         assert_eq!(
             bb.get_exact::<CustomEntry>("custom").as_ref(),
@@ -558,9 +551,6 @@ mod tests {
             Some(&custom_value)
         );
         // Check it returns None if it cannot be parsed
-        assert_eq!(
-            bb.get::<CustomEntry>("custom_str_malformed").as_ref(),
-            None
-        );
+        assert_eq!(bb.get::<CustomEntry>("custom_str_malformed").as_ref(), None);
     }
 }

--- a/behaviortree-rs/src/lib.rs
+++ b/behaviortree-rs/src/lib.rs
@@ -145,10 +145,14 @@ use behaviortree_rs::{
     sync::BoxFuture,
 };
 
-#[bt_node(SyncActionNode)]
+#[bt_node(
+    node_type = SyncActionNode,
+    ports = provided_ports,
+    tick = tick,
+)]
 struct DummyActionStruct {}
 
-impl AsyncTick for DummyActionStruct {
+impl DummyActionStruct {
     fn tick(&mut self) -> BoxFuture<Result<NodeStatus, NodeError>> {
         Box::pin(async move {
             // Some implementation
@@ -159,11 +163,7 @@ impl AsyncTick for DummyActionStruct {
             Ok(NodeStatus::Success)
         })
     }
-}
 
-// If you don't use any ports, this can be left empty
-// impl NodePorts for DummyActionStruct {}
-impl NodePorts for DummyActionStruct {
     fn provided_ports(&self) -> PortsList {
         define_ports!(
             // No default value
@@ -173,9 +173,6 @@ impl NodePorts for DummyActionStruct {
         )
     }
 }
-
-// If you don't need to do cleanup, leave as-is
-impl AsyncHalt for DummyActionStruct {}
 ```
 
 ### `SyncTick`

--- a/behaviortree-rs/src/nodes/control/fallback.rs
+++ b/behaviortree-rs/src/nodes/control/fallback.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult},
+    nodes::{ControlNode, NodeError, NodeResult},
 };
 
 /// The FallbackNode is used to try different strategies,

--- a/behaviortree-rs/src/nodes/control/fallback.rs
+++ b/behaviortree-rs/src/nodes/control/fallback.rs
@@ -19,6 +19,7 @@ use crate::{
 #[bt_node(
     node_type = ControlNode,
     tick = tick,
+    halt = halt,
 )]
 pub struct FallbackNode {
     #[bt(default = "0")]
@@ -27,7 +28,7 @@ pub struct FallbackNode {
     all_skipped: bool,
 }
 
-impl AsyncTick for FallbackNode {
+impl FallbackNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             if self.status == NodeStatus::Idle {
@@ -79,11 +80,7 @@ impl AsyncTick for FallbackNode {
             }
         })
     }
-}
 
-impl NodePorts for FallbackNode {}
-
-impl AsyncHalt for FallbackNode {
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.child_idx = 0;

--- a/behaviortree-rs/src/nodes/control/fallback.rs
+++ b/behaviortree-rs/src/nodes/control/fallback.rs
@@ -16,7 +16,10 @@ use crate::{
 ///
 /// - If a child returns SUCCESS, stop the loop and return SUCCESS.
 // #[derive(TreeNodeDefaults, ControlNode, Debug, Clone)]
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    tick = tick,
+)]
 pub struct FallbackNode {
     #[bt(default = "0")]
     child_idx: usize,

--- a/behaviortree-rs/src/nodes/control/if_then_else.rs
+++ b/behaviortree-rs/src/nodes/control/if_then_else.rs
@@ -4,7 +4,7 @@ use log::warn;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult},
+    nodes::{ControlNode, NodeError, NodeResult},
 };
 
 /// IfThenElseNode must have exactly 2 or 3 children. This node is NOT reactive.

--- a/behaviortree-rs/src/nodes/control/if_then_else.rs
+++ b/behaviortree-rs/src/nodes/control/if_then_else.rs
@@ -19,13 +19,17 @@ use crate::{
 /// statement returns FAILURE.
 ///
 /// This is equivalent to add AlwaysFailure as 3rd child.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct IfThenElseNode {
     #[bt(default = "0")]
     child_idx: usize,
 }
 
-impl AsyncTick for IfThenElseNode {
+impl IfThenElseNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             let children_count = self.children.len();
@@ -77,11 +81,7 @@ impl AsyncTick for IfThenElseNode {
             ))
         })
     }
-}
 
-impl NodePorts for IfThenElseNode {}
-
-impl AsyncHalt for IfThenElseNode {
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.child_idx = 0;

--- a/behaviortree-rs/src/nodes/control/parallel.rs
+++ b/behaviortree-rs/src/nodes/control/parallel.rs
@@ -7,7 +7,7 @@ use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
     nodes::{
-        AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult, TreeNodeDefaults,
+        ControlNode, NodeError, NodeResult, TreeNodeDefaults,
     },
 };
 
@@ -146,7 +146,7 @@ impl ParallelNode {
             input_port!("failure_count", 1)
         )
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/parallel.rs
+++ b/behaviortree-rs/src/nodes/control/parallel.rs
@@ -28,7 +28,12 @@ use crate::{
 /// https://www.i2tutorials.com/what-are-negative-indexes-and-why-are-they-used/
 ///
 /// Therefore -1 is equivalent to the number of children.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    ports = provided_ports,
+    tick = tick,
+    halt = halt,
+)]
 pub struct ParallelNode {
     #[bt(default = "-1")]
     success_threshold: i32,
@@ -64,9 +69,7 @@ impl ParallelNode {
         self.success_count = 0;
         self.failure_count = 0;
     }
-}
 
-impl AsyncTick for ParallelNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             self.success_threshold = self.config_mut().get_input("success_count").unwrap();
@@ -136,18 +139,14 @@ impl AsyncTick for ParallelNode {
             }
         })
     }
-}
 
-impl NodePorts for ParallelNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(
             input_port!("success_count", -1),
             input_port!("failure_count", 1)
         )
     }
-}
-
-impl AsyncHalt for ParallelNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/parallel.rs
+++ b/behaviortree-rs/src/nodes/control/parallel.rs
@@ -6,9 +6,7 @@ use futures::future::BoxFuture;
 use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
-    nodes::{
-        ControlNode, NodeError, NodeResult, TreeNodeDefaults,
-    },
+    nodes::{ControlNode, NodeError, NodeResult, TreeNodeDefaults},
 };
 
 /// The ParallelNode execute all its children

--- a/behaviortree-rs/src/nodes/control/parallel_all.rs
+++ b/behaviortree-rs/src/nodes/control/parallel_all.rs
@@ -6,9 +6,7 @@ use futures::future::BoxFuture;
 use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
-    nodes::{
-        ControlNode, NodeError, NodeResult, TreeNodeDefaults,
-    },
+    nodes::{ControlNode, NodeError, NodeResult, TreeNodeDefaults},
 };
 
 /// The ParallelAllNode execute all its children
@@ -115,7 +113,7 @@ impl ParallelAllNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("max_failures", 1))
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/parallel_all.rs
+++ b/behaviortree-rs/src/nodes/control/parallel_all.rs
@@ -7,7 +7,7 @@ use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
     nodes::{
-        AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult, TreeNodeDefaults,
+        ControlNode, NodeError, NodeResult, TreeNodeDefaults,
     },
 };
 

--- a/behaviortree-rs/src/nodes/control/parallel_all.rs
+++ b/behaviortree-rs/src/nodes/control/parallel_all.rs
@@ -22,7 +22,12 @@ use crate::{
 /// https://www.i2tutorials.com/what-are-negative-indexes-and-why-are-they-used/
 ///
 /// Therefore -1 is equivalent to the number of children.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    ports = provided_ports,
+    tick = tick,
+    halt = halt,
+)]
 pub struct ParallelAllNode {
     #[bt(default = "-1")]
     failure_threshold: i32,
@@ -40,9 +45,7 @@ impl ParallelAllNode {
             self.failure_threshold as usize
         }
     }
-}
 
-impl AsyncTick for ParallelAllNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             self.failure_threshold = self.config_mut().get_input("max_failures")?;
@@ -108,15 +111,11 @@ impl AsyncTick for ParallelAllNode {
             Ok(NodeStatus::Running)
         })
     }
-}
 
-impl NodePorts for ParallelAllNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("max_failures", 1))
     }
-}
-
-impl AsyncHalt for ParallelAllNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/reactive_fallback.rs
+++ b/behaviortree-rs/src/nodes/control/reactive_fallback.rs
@@ -17,10 +17,14 @@ use crate::{
 ///
 /// IMPORTANT: to work properly, this node should not have more than
 ///            a single asynchronous child.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct ReactiveFallbackNode {}
 
-impl AsyncTick for ReactiveFallbackNode {
+impl ReactiveFallbackNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             let mut all_skipped = true;
@@ -66,11 +70,7 @@ impl AsyncTick for ReactiveFallbackNode {
             }
         })
     }
-}
-
-impl NodePorts for ReactiveFallbackNode {}
-
-impl AsyncHalt for ReactiveFallbackNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/reactive_fallback.rs
+++ b/behaviortree-rs/src/nodes/control/reactive_fallback.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult},
+    nodes::{ControlNode, NodeError, NodeResult},
 };
 
 /// The ReactiveFallback is similar to a ParallelNode.
@@ -70,7 +70,7 @@ impl ReactiveFallbackNode {
             }
         })
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/reactive_sequence.rs
+++ b/behaviortree-rs/src/nodes/control/reactive_sequence.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult},
+    nodes::{ControlNode, NodeError, NodeResult},
 };
 
 /// The ReactiveSequence is similar to a ParallelNode.

--- a/behaviortree-rs/src/nodes/control/reactive_sequence.rs
+++ b/behaviortree-rs/src/nodes/control/reactive_sequence.rs
@@ -17,13 +17,17 @@ use crate::{
 ///
 /// IMPORTANT: to work properly, this node should not have more than a single
 ///            asynchronous child.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct ReactiveSequenceNode {
     #[bt(default = "-1")]
     running_child: i32,
 }
 
-impl AsyncTick for ReactiveSequenceNode {
+impl ReactiveSequenceNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             let mut all_skipped = true;
@@ -79,11 +83,7 @@ impl AsyncTick for ReactiveSequenceNode {
             }
         })
     }
-}
 
-impl NodePorts for ReactiveSequenceNode {}
-
-impl AsyncHalt for ReactiveSequenceNode {
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/sequence.rs
+++ b/behaviortree-rs/src/nodes/control/sequence.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult},
+    nodes::{ControlNode, NodeError, NodeResult},
 };
 
 /// The SequenceNode is used to tick children in an ordered sequence.

--- a/behaviortree-rs/src/nodes/control/sequence.rs
+++ b/behaviortree-rs/src/nodes/control/sequence.rs
@@ -15,7 +15,11 @@ use crate::{
 ///   Loop is NOT restarted, the same running child will be ticked again.
 ///
 /// - If a child returns FAILURE, stop the loop and return FAILURE.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct SequenceNode {
     #[bt(default = "0")]
     child_idx: usize,
@@ -23,7 +27,7 @@ pub struct SequenceNode {
     all_skipped: bool,
 }
 
-impl AsyncTick for SequenceNode {
+impl SequenceNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             if self.status == NodeStatus::Idle {
@@ -67,11 +71,7 @@ impl AsyncTick for SequenceNode {
             Ok(NodeStatus::Success)
         })
     }
-}
 
-impl NodePorts for SequenceNode {}
-
-impl AsyncHalt for SequenceNode {
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.child_idx = 0;

--- a/behaviortree-rs/src/nodes/control/sequence_star.rs
+++ b/behaviortree-rs/src/nodes/control/sequence_star.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult},
+    nodes::{ControlNode, NodeError, NodeResult},
 };
 /// The SequenceStarNode is used to tick children in an ordered sequence.
 /// If any child returns RUNNING, previous children are not ticked again.

--- a/behaviortree-rs/src/nodes/control/sequence_star.rs
+++ b/behaviortree-rs/src/nodes/control/sequence_star.rs
@@ -15,7 +15,11 @@ use crate::{
 ///
 /// - If a child returns FAILURE, stop the loop and return FAILURE.
 ///   Loop is NOT restarted, the same running child will be ticked again.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct SequenceWithMemoryNode {
     #[bt(default = "0")]
     child_idx: usize,
@@ -23,7 +27,7 @@ pub struct SequenceWithMemoryNode {
     all_skipped: bool,
 }
 
-impl AsyncTick for SequenceWithMemoryNode {
+impl SequenceWithMemoryNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             if self.status == NodeStatus::Idle {
@@ -73,11 +77,7 @@ impl AsyncTick for SequenceWithMemoryNode {
             }
         })
     }
-}
 
-impl NodePorts for SequenceWithMemoryNode {}
-
-impl AsyncHalt for SequenceWithMemoryNode {
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.child_idx = 0;

--- a/behaviortree-rs/src/nodes/control/while_do_else.rs
+++ b/behaviortree-rs/src/nodes/control/while_do_else.rs
@@ -17,10 +17,14 @@ use crate::{
 ///
 /// If the 2nd or 3d child is RUNNING and the statement changes,
 /// the RUNNING child will be stopped before starting the sibling.
-#[bt_node(ControlNode)]
+#[bt_node(
+    node_type = ControlNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct WhileDoElseNode {}
 
-impl AsyncTick for WhileDoElseNode {
+impl WhileDoElseNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             let children_count = self.children.len();
@@ -71,11 +75,7 @@ impl AsyncTick for WhileDoElseNode {
             }
         })
     }
-}
 
-impl NodePorts for WhileDoElseNode {}
-
-impl AsyncHalt for WhileDoElseNode {
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_children().await;

--- a/behaviortree-rs/src/nodes/control/while_do_else.rs
+++ b/behaviortree-rs/src/nodes/control/while_do_else.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, ControlNode, NodeError, NodePorts, NodeResult},
+    nodes::{ControlNode, NodeError, NodeResult},
 };
 
 /// WhileDoElse must have exactly 2 or 3 children.

--- a/behaviortree-rs/src/nodes/decorator/force_failure.rs
+++ b/behaviortree-rs/src/nodes/decorator/force_failure.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, DecoratorNode, NodePorts, NodeResult, TreeNodeDefaults},
+    nodes::{DecoratorNode, NodeResult, TreeNodeDefaults},
 };
 
 /// The ForceFailureNode returns always Failure or Running
@@ -30,7 +30,7 @@ impl ForceFailureNode {
             Ok(child_status)
         })
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/force_failure.rs
+++ b/behaviortree-rs/src/nodes/decorator/force_failure.rs
@@ -7,10 +7,14 @@ use crate::{
 };
 
 /// The ForceFailureNode returns always Failure or Running
-#[bt_node(DecoratorNode)]
+#[bt_node(
+    node_type = DecoratorNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct ForceFailureNode {}
 
-impl AsyncTick for ForceFailureNode {
+impl ForceFailureNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             self.set_status(NodeStatus::Running);
@@ -26,11 +30,7 @@ impl AsyncTick for ForceFailureNode {
             Ok(child_status)
         })
     }
-}
-
-impl NodePorts for ForceFailureNode {}
-
-impl AsyncHalt for ForceFailureNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/force_success.rs
+++ b/behaviortree-rs/src/nodes/decorator/force_success.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, DecoratorNode, NodePorts, NodeResult, TreeNodeDefaults},
+    nodes::{DecoratorNode, NodeResult, TreeNodeDefaults},
 };
 
 /// The ForceSuccessNode returns always Success or Running
@@ -30,7 +30,7 @@ impl ForceSuccessNode {
             Ok(child_status)
         })
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/force_success.rs
+++ b/behaviortree-rs/src/nodes/decorator/force_success.rs
@@ -7,10 +7,14 @@ use crate::{
 };
 
 /// The ForceSuccessNode returns always Success or Running
-#[bt_node(DecoratorNode)]
+#[bt_node(
+    node_type = DecoratorNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct ForceSuccessNode {}
 
-impl AsyncTick for ForceSuccessNode {
+impl ForceSuccessNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             self.set_status(NodeStatus::Running);
@@ -26,11 +30,7 @@ impl AsyncTick for ForceSuccessNode {
             Ok(child_status)
         })
     }
-}
-
-impl NodePorts for ForceSuccessNode {}
-
-impl AsyncHalt for ForceSuccessNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/inverter.rs
+++ b/behaviortree-rs/src/nodes/decorator/inverter.rs
@@ -3,9 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{
-        DecoratorNode, NodeError, NodeResult, TreeNodeDefaults,
-    },
+    nodes::{DecoratorNode, NodeError, NodeResult, TreeNodeDefaults},
 };
 
 /// The InverterNode returns Failure on Success, and Success on Failure

--- a/behaviortree-rs/src/nodes/decorator/inverter.rs
+++ b/behaviortree-rs/src/nodes/decorator/inverter.rs
@@ -9,10 +9,14 @@ use crate::{
 };
 
 /// The InverterNode returns Failure on Success, and Success on Failure
-#[bt_node(DecoratorNode)]
+#[bt_node(
+    node_type = DecoratorNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct InverterNode {}
 
-impl AsyncTick for InverterNode {
+impl InverterNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             self.set_status(NodeStatus::Running);
@@ -36,11 +40,7 @@ impl AsyncTick for InverterNode {
             }
         })
     }
-}
 
-impl NodePorts for InverterNode {}
-
-impl AsyncHalt for InverterNode {
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/inverter.rs
+++ b/behaviortree-rs/src/nodes/decorator/inverter.rs
@@ -4,7 +4,7 @@ use futures::future::BoxFuture;
 use crate::{
     basic_types::NodeStatus,
     nodes::{
-        AsyncHalt, AsyncTick, DecoratorNode, NodeError, NodePorts, NodeResult, TreeNodeDefaults,
+        DecoratorNode, NodeError, NodeResult, TreeNodeDefaults,
     },
 };
 

--- a/behaviortree-rs/src/nodes/decorator/keep_running_until_failure.rs
+++ b/behaviortree-rs/src/nodes/decorator/keep_running_until_failure.rs
@@ -3,7 +3,7 @@ use futures::future::BoxFuture;
 
 use crate::{
     basic_types::NodeStatus,
-    nodes::{AsyncHalt, AsyncTick, DecoratorNode, NodePorts, NodeResult, TreeNodeDefaults},
+    nodes::{DecoratorNode, NodeResult, TreeNodeDefaults},
 };
 
 /// The KeepRunningUntilFailureNode returns always Failure or Running
@@ -34,7 +34,7 @@ impl KeepRunningUntilFailureNode {
             }
         })
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/keep_running_until_failure.rs
+++ b/behaviortree-rs/src/nodes/decorator/keep_running_until_failure.rs
@@ -7,10 +7,14 @@ use crate::{
 };
 
 /// The KeepRunningUntilFailureNode returns always Failure or Running
-#[bt_node(DecoratorNode)]
+#[bt_node(
+    node_type = DecoratorNode,
+    tick = tick,
+    halt = halt,
+)]
 pub struct KeepRunningUntilFailureNode {}
 
-impl AsyncTick for KeepRunningUntilFailureNode {
+impl KeepRunningUntilFailureNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             self.set_status(NodeStatus::Running);
@@ -30,11 +34,7 @@ impl AsyncTick for KeepRunningUntilFailureNode {
             }
         })
     }
-}
-
-impl NodePorts for KeepRunningUntilFailureNode {}
-
-impl AsyncHalt for KeepRunningUntilFailureNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/repeat.rs
+++ b/behaviortree-rs/src/nodes/decorator/repeat.rs
@@ -24,7 +24,12 @@ use crate::{
 ///   <ClapYourHandsOnce/>
 /// </Repeat>
 /// ```
-#[bt_node(DecoratorNode)]
+#[bt_node(
+    node_type = DecoratorNode,
+    ports = provided_ports,
+    tick = tick,
+    halt = halt,
+)]
 pub struct RepeatNode {
     #[bt(default = "-1")]
     num_cycles: i32,
@@ -34,7 +39,7 @@ pub struct RepeatNode {
     all_skipped: bool,
 }
 
-impl AsyncTick for RepeatNode {
+impl RepeatNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             // Load num_cycles from the port value
@@ -90,15 +95,11 @@ impl AsyncTick for RepeatNode {
             }
         })
     }
-}
 
-impl NodePorts for RepeatNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("num_cycles"))
     }
-}
-
-impl AsyncHalt for RepeatNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.repeat_count = 0;

--- a/behaviortree-rs/src/nodes/decorator/repeat.rs
+++ b/behaviortree-rs/src/nodes/decorator/repeat.rs
@@ -4,9 +4,7 @@ use futures::future::BoxFuture;
 use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
-    nodes::{
-        DecoratorNode, NodeError, NodeResult, TreeNodeDefaults,
-    },
+    nodes::{DecoratorNode, NodeError, NodeResult, TreeNodeDefaults},
 };
 
 /// /// The RetryNode is used to execute a child several times, as long

--- a/behaviortree-rs/src/nodes/decorator/repeat.rs
+++ b/behaviortree-rs/src/nodes/decorator/repeat.rs
@@ -5,7 +5,7 @@ use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
     nodes::{
-        AsyncHalt, AsyncTick, DecoratorNode, NodeError, NodePorts, NodeResult, TreeNodeDefaults,
+        DecoratorNode, NodeError, NodeResult, TreeNodeDefaults,
     },
 };
 
@@ -99,7 +99,7 @@ impl RepeatNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("num_cycles"))
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.repeat_count = 0;

--- a/behaviortree-rs/src/nodes/decorator/retry.rs
+++ b/behaviortree-rs/src/nodes/decorator/retry.rs
@@ -5,7 +5,7 @@ use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
     nodes::{
-        AsyncHalt, AsyncTick, DecoratorNode, NodeError, NodePorts, NodeResult, TreeNodeDefaults,
+        DecoratorNode, NodeError, NodeResult, TreeNodeDefaults,
     },
 };
 
@@ -100,7 +100,7 @@ impl RetryNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("num_attempts"))
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.try_count = 0;

--- a/behaviortree-rs/src/nodes/decorator/retry.rs
+++ b/behaviortree-rs/src/nodes/decorator/retry.rs
@@ -24,7 +24,12 @@ use crate::{
 ///     <OpenDoor/>
 /// </RetryUntilSuccessful>
 /// ```
-#[bt_node(DecoratorNode)]
+#[bt_node(
+    node_type = DecoratorNode,
+    ports = provided_ports,
+    tick = tick,
+    halt = halt,
+)]
 pub struct RetryNode {
     #[bt(default = "-1")]
     max_attempts: i32,
@@ -34,7 +39,7 @@ pub struct RetryNode {
     all_skipped: bool,
 }
 
-impl AsyncTick for RetryNode {
+impl RetryNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             // Load num_cycles from the port value
@@ -91,15 +96,11 @@ impl AsyncTick for RetryNode {
             }
         })
     }
-}
 
-impl NodePorts for RetryNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("num_attempts"))
     }
-}
-
-impl AsyncHalt for RetryNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.try_count = 0;

--- a/behaviortree-rs/src/nodes/decorator/retry.rs
+++ b/behaviortree-rs/src/nodes/decorator/retry.rs
@@ -4,9 +4,7 @@ use futures::future::BoxFuture;
 use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
-    nodes::{
-        DecoratorNode, NodeError, NodeResult, TreeNodeDefaults,
-    },
+    nodes::{DecoratorNode, NodeError, NodeResult, TreeNodeDefaults},
 };
 
 /// The RetryNode is used to execute a child several times if it fails.

--- a/behaviortree-rs/src/nodes/decorator/run_once.rs
+++ b/behaviortree-rs/src/nodes/decorator/run_once.rs
@@ -4,7 +4,7 @@ use futures::future::BoxFuture;
 use crate::{
     basic_types::NodeStatus,
     macros::{define_ports, input_port},
-    nodes::{AsyncHalt, AsyncTick, DecoratorNode, NodePorts, NodeResult, TreeNodeDefaults},
+    nodes::{DecoratorNode, NodeResult, TreeNodeDefaults},
 };
 
 /// The RunOnceNode is used when you want to execute the child
@@ -59,7 +59,7 @@ impl RunOnceNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("then_skip", true))
     }
-    
+
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/decorator/run_once.rs
+++ b/behaviortree-rs/src/nodes/decorator/run_once.rs
@@ -16,7 +16,12 @@ use crate::{
 ///
 /// - if TRUE (default), the node will be skipped in the future.
 /// - if FALSE, return synchronously the same status returned by the child, forever.
-#[bt_node(DecoratorNode)]
+#[bt_node(
+    node_type = DecoratorNode,
+    ports = provided_ports,
+    tick = tick,
+    halt = halt,
+)]
 pub struct RunOnceNode {
     #[bt(default = "false")]
     already_ticked: bool,
@@ -24,7 +29,7 @@ pub struct RunOnceNode {
     returned_status: NodeStatus,
 }
 
-impl AsyncTick for RunOnceNode {
+impl RunOnceNode {
     fn tick(&mut self) -> BoxFuture<NodeResult> {
         Box::pin(async move {
             let skip = self.config.get_input("then_skip")?;
@@ -50,15 +55,11 @@ impl AsyncTick for RunOnceNode {
             Ok(status)
         })
     }
-}
 
-impl NodePorts for RunOnceNode {
     fn provided_ports(&self) -> crate::basic_types::PortsList {
         define_ports!(input_port!("then_skip", true))
     }
-}
-
-impl AsyncHalt for RunOnceNode {
+    
     fn halt(&mut self) -> BoxFuture<()> {
         Box::pin(async move {
             self.reset_child().await;

--- a/behaviortree-rs/src/nodes/mod.rs
+++ b/behaviortree-rs/src/nodes/mod.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 
 use crate::{
     basic_types::{
-        self, get_remapped_key, FromString, ParseStr, PortDirection, PortValue,
-        PortsRemapping, TreeNodeManifest,
+        self, get_remapped_key, FromString, ParseStr, PortDirection, PortValue, PortsRemapping,
+        TreeNodeManifest,
     },
     blackboard::BlackboardString,
     tree::ParseError,

--- a/behaviortree-rs/src/tree.rs
+++ b/behaviortree-rs/src/tree.rs
@@ -16,10 +16,7 @@ use crate::{
     },
     blackboard::{Blackboard, BlackboardString},
     macros::build_node_ptr,
-    nodes::{
-        self, AsyncHalt, NodeConfig,
-        NodeResult, TreeNodePtr,
-    },
+    nodes::{self, AsyncHalt, NodeConfig, NodeResult, TreeNodePtr},
 };
 
 #[derive(Debug, Error)]
@@ -499,10 +496,9 @@ impl Factory {
                             for (attr, value) in attributes.iter() {
                                 // Set autoremapping to true or false
                                 if attr == "_autoremap" {
-                                    child_blackboard
-                                        .enable_auto_remapping(<bool as FromString>::from_string(
-                                            value,
-                                        )?);
+                                    child_blackboard.enable_auto_remapping(
+                                        <bool as FromString>::from_string(value)?,
+                                    );
                                     continue;
                                 } else if !attr.is_allowed_port_name() {
                                     continue;
@@ -510,8 +506,7 @@ impl Factory {
 
                                 if let Some(port_name) = value.strip_bb_pointer() {
                                     // Add remapping if `value` is a Blackboard pointer
-                                    child_blackboard
-                                        .add_subtree_remapping(attr.clone(), port_name);
+                                    child_blackboard.add_subtree_remapping(attr.clone(), port_name);
                                 } else {
                                     // Set string value into Blackboard
                                     child_blackboard.set(attr, value.clone());

--- a/behaviortree-rs/tests/control_tests.rs
+++ b/behaviortree-rs/tests/control_tests.rs
@@ -5,8 +5,8 @@ mod nodes;
 
 use nodes::{EchoNode, RunForNode, StatusNode};
 
-#[test]
-fn fallback() {
+#[tokio::test]
+async fn fallback() {
     nodes::test_setup();
 
     let xml = r#"
@@ -32,16 +32,16 @@ fn fallback() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("{status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn if_then_else() {
+#[tokio::test]
+async fn if_then_else() {
     nodes::test_setup();
 
     let xml = r#"
@@ -66,16 +66,16 @@ fn if_then_else() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn parallel_all() {
+#[tokio::test]
+async fn parallel_all() {
     nodes::test_setup();
 
     let xml = r#"
@@ -101,16 +101,16 @@ fn parallel_all() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn parallel() {
+#[tokio::test]
+async fn parallel() {
     nodes::test_setup();
 
     let xml = r#"
@@ -138,16 +138,16 @@ fn parallel() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn reactive_fallback() {
+#[tokio::test]
+async fn reactive_fallback() {
     nodes::test_setup();
 
     let xml = r#"
@@ -172,16 +172,16 @@ fn reactive_fallback() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn reactive_sequence() {
+#[tokio::test]
+async fn reactive_sequence() {
     nodes::test_setup();
 
     let xml = r#"
@@ -208,16 +208,16 @@ fn reactive_sequence() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn sequence_star() {
+#[tokio::test]
+async fn sequence_star() {
     nodes::test_setup();
 
     let xml = r#"
@@ -244,16 +244,16 @@ fn sequence_star() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn sequence_vanilla() {
+#[tokio::test]
+async fn sequence_vanilla() {
     nodes::test_setup();
 
     let xml = r#"
@@ -280,16 +280,16 @@ fn sequence_vanilla() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }
 }
 
-#[test]
-fn while_do_else() {
+#[tokio::test]
+async fn while_do_else() {
     nodes::test_setup();
 
     let xml = r#"
@@ -315,9 +315,9 @@ fn while_do_else() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_sync_tree(&blackboard, "main").unwrap();
+    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
 
-    match tree.tick_while_running() {
+    match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
         Err(e) => error!("{e}"),
     }

--- a/behaviortree-rs/tests/control_tests.rs
+++ b/behaviortree-rs/tests/control_tests.rs
@@ -32,7 +32,10 @@ async fn fallback() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("{status:?}"),
@@ -66,7 +69,10 @@ async fn if_then_else() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
@@ -101,7 +107,10 @@ async fn parallel_all() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
@@ -138,7 +147,10 @@ async fn parallel() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
@@ -172,7 +184,10 @@ async fn reactive_fallback() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
@@ -208,7 +223,10 @@ async fn reactive_sequence() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
@@ -244,7 +262,10 @@ async fn sequence_star() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
@@ -280,7 +301,10 @@ async fn sequence_vanilla() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),
@@ -315,7 +339,10 @@ async fn while_do_else() {
 
     factory.register_bt_from_text(xml).unwrap();
 
-    let mut tree = factory.instantiate_async_tree(&blackboard, "main").await.unwrap();
+    let mut tree = factory
+        .instantiate_async_tree(&blackboard, "main")
+        .await
+        .unwrap();
 
     match tree.tick_while_running().await {
         Ok(status) => info!("Final status: {status:?}"),


### PR DESCRIPTION
# TODOs
* Figure out how `init` method should work: can't run from `new()` if it wants to use `self`, so how to do?