### PR TITLE
Examples from BehaviorTree.CPP tutorial

### DIFF
--- a/behaviortree-rs/Cargo.toml
+++ b/behaviortree-rs/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 repository.workspace = true
+exclude = ["examples/**"]
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -23,6 +24,7 @@ thiserror = "1.0.47"
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"
+rand = "0.8"
 rstest = "0.23.0"
 tokio = { version = "1.32.0", features = ["macros"] }
 tokio-test = "0.4.3"

--- a/behaviortree-rs/examples/01_first/first.xml
+++ b/behaviortree-rs/examples/01_first/first.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root BTCPP_format="4"
+      main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <Sequence>
+      <CheckBattery   name="check_battery"/>
+      <OpenGripper    name="open_gripper"/>
+      <ApproachObject name="approach_object"/>
+      <CloseGripper   name="close_gripper"/>
+    </Sequence>
+  </BehaviorTree>
+
+  <!-- Description of Node Models (used by Groot) -->
+  <TreeNodesModel>
+    <Action ID="ApproachObject"
+            editable="true"/>
+    <Condition ID="CheckBattery"
+               editable="true"/>
+    <Action ID="CloseGripper"
+            editable="true"/>
+    <Action ID="OpenGripper"
+            editable="true"/>
+  </TreeNodesModel>
+
+</root>

--- a/behaviortree-rs/examples/01_first/main.rs
+++ b/behaviortree-rs/examples/01_first/main.rs
@@ -1,0 +1,117 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the first tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_01_first_tree
+//!
+//! Differences to BehaviorTree.CPP:
+//! - we cannot register functions/methods of a struct/class
+//! - there is no separate ConditionNode type, these have to be implemented as SyncActionNode
+//!
+
+use std::{fs::File, io::Read, path::PathBuf};
+
+use behaviortree_rs::prelude::*;
+
+/// ConditionNode "CheckBattery"
+#[bt_node(SyncActionNode)]
+struct CheckBattery {}
+
+#[bt_node(SyncActionNode)]
+impl CheckBattery {
+    async fn tick(&mut self) -> NodeResult {
+        println!("battery state is ok");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("name"))
+    }
+}
+
+/// SyncActionNode "OpenGripper"
+#[bt_node(SyncActionNode)]
+struct OpenGripper {}
+
+#[bt_node(SyncActionNode)]
+impl OpenGripper {
+    async fn tick(&mut self) -> NodeResult {
+        println!("opened gripper");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("name"))
+    }
+}
+
+/// SyncActionNode "ApproachObject"
+#[bt_node(SyncActionNode)]
+struct ApproachObject {}
+
+#[bt_node(SyncActionNode)]
+impl ApproachObject {
+    async fn tick(&mut self) -> NodeResult {
+        println!("approaching object");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("name"))
+    }
+}
+
+/// SyncActionNode "CloseGripper"
+#[bt_node(SyncActionNode)]
+struct CloseGripper {}
+
+#[bt_node(SyncActionNode)]
+impl CloseGripper {
+    async fn tick(&mut self) -> NodeResult {
+        println!("closed gripper");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("name"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register all needed nodes
+    register_action_node!(factory, "CheckBattery", CheckBattery);
+    register_action_node!(factory, "OpenGripper", OpenGripper);
+    register_action_node!(factory, "ApproachObject", ApproachObject);
+    register_action_node!(factory, "CloseGripper", CloseGripper);
+
+    // construct path to examples xml independant of current directory in project
+    let mut directory = std::env::current_dir()?.to_str().unwrap().to_string();
+    let pos = directory.find("behaviortree-rs").expect("wrong path");
+    directory.replace_range(pos.., "behaviortree-rs");
+    let path = PathBuf::from(directory)
+        .join(file!())
+        .parent()
+        .expect("no path to file")
+        .join("first.xml");
+
+    // read xml from file
+    let mut file = File::open(path)?;
+    let mut xml = String::new();
+    file.read_to_string(&mut xml)?;
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(xml, &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/02_ports/main.rs
+++ b/behaviortree-rs/examples/02_ports/main.rs
@@ -1,0 +1,81 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the second tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_02_basic_ports
+//!
+
+use std::{fs::File, io::Read, path::PathBuf};
+
+use behaviortree_rs::prelude::*;
+
+/// SyncActionNode "SaySomething"
+#[bt_node(SyncActionNode)]
+struct SaySomething {}
+
+#[bt_node(SyncActionNode)]
+impl SaySomething {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("message")?;
+
+        println!("Robot says: {msg}");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("message", "hello"))
+    }
+}
+
+/// SyncActionNode "ThinkWhatToSay"
+#[bt_node(SyncActionNode)]
+struct ThinkWhatToSay {}
+
+#[bt_node(SyncActionNode)]
+impl ThinkWhatToSay {
+    async fn tick(&mut self) -> NodeResult {
+        node_.config.set_output("text", "The answer is 42.").await?;
+
+        println!("Robot has thought");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(output_port!("text"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register all needed nodes
+    register_action_node!(factory, "SaySomething", SaySomething);
+    register_action_node!(factory, "ThinkWhatToSay", ThinkWhatToSay);
+
+    // construct path to examples xml independant of current directory in project
+    let mut directory = std::env::current_dir()?.to_str().unwrap().to_string();
+    let pos = directory.find("behaviortree-rs").expect("wrong path");
+    directory.replace_range(pos.., "behaviortree-rs");
+    let path = PathBuf::from(directory)
+        .join(file!())
+        .parent()
+        .expect("no path to file")
+        .join("ports.xml");
+
+    // read xml from file
+    let mut file = File::open(path)?;
+    let mut xml = String::new();
+    file.read_to_string(&mut xml)?;
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(xml, &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/02_ports/ports.xml
+++ b/behaviortree-rs/examples/02_ports/ports.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root BTCPP_format="4">
+  <BehaviorTree ID="MainTree">
+    <Sequence>
+      <SaySomething message="Hello."/>
+      <ThinkWhatToSay text="{the_answer}"/>
+      <SaySomething message="{the_answer}"/>
+    </Sequence>
+  </BehaviorTree>
+
+  <!-- Description of Node Models (used by Groot) -->
+  <TreeNodesModel>
+    <Action ID="SaySomething"
+            editable="true">
+      <input_port name="message"
+                  default="Hello"/>
+    </Action>
+    <Action ID="ThinkWhatToSay"
+            editable="true">
+      <output_port name="text"
+                   default="Nothing to say"/>
+    </Action>
+  </TreeNodesModel>
+
+</root>

--- a/behaviortree-rs/examples/03_ports_generic/main.rs
+++ b/behaviortree-rs/examples/03_ports_generic/main.rs
@@ -1,0 +1,134 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the third tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_03_generic_ports
+//!
+//! Differences to BehaviorTree.CPP
+//! - there is no Script node available, that has to be implemented by user
+//!
+
+use std::{num::ParseFloatError, str::FromStr};
+
+use behaviortree_rs::{basic_types::FromString, nodes::NodeError, prelude::*};
+use behaviortree_rs_derive::FromString;
+
+const XML: &str = r#"
+<root BTCPP_format="4" >
+    <BehaviorTree ID="MainTree">
+       <Sequence>
+           <CalculateGoal goal="{GoalPosition}" />
+           <PrintTarget   target="{GoalPosition}" />
+           <Script        code=" OtherGoal:=&apos;-1;3&apos; " />
+           <PrintTarget   target="{OtherGoal}" />
+       </Sequence>
+    </BehaviorTree>
+</root>
+"#;
+
+#[derive(Clone, Copy, Debug, FromString)]
+struct Position2D {
+    x: f64,
+    y: f64,
+}
+
+impl FromStr for Position2D {
+    type Err = ParseFloatError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // remove redundant ' and &apos; from string
+        let s = value
+            .replace("'", "")
+            .trim()
+            .replace("&apos;", "")
+            .trim()
+            .to_string();
+        let v: Vec<&str> = s.split(';').collect();
+        let x = f64::from_string(v[0])?;
+        let y = f64::from_string(v[1])?;
+        Ok(Self { x, y })
+    }
+}
+
+/// SyncActionNode "CalculateGoal"
+#[bt_node(SyncActionNode)]
+struct CalculateGoal {}
+
+#[bt_node(SyncActionNode)]
+impl CalculateGoal {
+    async fn tick(&mut self) -> NodeResult {
+        // initialize GoalPosition
+        let pos = Position2D { x: 1.1, y: 2.3 };
+        node_.config.set_output("goal", pos).await?;
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(output_port!("goal"))
+    }
+}
+
+/// SyncActionNode "PrintTarget"
+#[bt_node(SyncActionNode)]
+struct PrintTarget {}
+
+#[bt_node(SyncActionNode)]
+impl PrintTarget {
+    async fn tick(&mut self) -> NodeResult {
+        let pos: Position2D = node_.config.get_input("target")?;
+
+        println!("Target positions: [ {}, {} ]", pos.x, pos.y);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("target"))
+    }
+}
+
+/// SyncActionNode "Script"
+#[bt_node(SyncActionNode)]
+struct Script {}
+
+#[bt_node(SyncActionNode)]
+impl Script {
+    async fn tick(&mut self) -> NodeResult {
+        let script: String = node_.config.get_input("code")?;
+        let elements: Vec<&str> = script.split(":=").collect();
+        let pos = Position2D::from_string(elements[1].trim()).map_err(|_| {
+            NodeError::PortValueParseError("code".to_string(), "Position2D".to_string())
+        })?;
+        node_
+            .config
+            .blackboard()
+            .to_owned()
+            .set(elements[0].trim(), pos);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("code"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register all needed nodes
+    register_action_node!(factory, "CalculateGoal", CalculateGoal);
+    register_action_node!(factory, "PrintTarget", PrintTarget);
+    register_action_node!(factory, "Script", Script);
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(XML.to_string(), &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/04_reactive/main.rs
+++ b/behaviortree-rs/examples/04_reactive/main.rs
@@ -1,0 +1,155 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the fourth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_04_sequence
+//!
+//! Differences to BehaviorTree.CPP
+//! - there is no tree::sleep(...) available, using sleep of async runtime instead,
+//!   which is not interrupted,when tree state changes
+//!
+
+extern crate tokio;
+
+use std::{num::ParseFloatError, str::FromStr, time::Duration};
+
+use behaviortree_rs::{basic_types::FromString, prelude::*};
+use behaviortree_rs_derive::FromString;
+
+const XML: &str = r#"
+<root BTCPP_format="4">
+    <BehaviorTree ID="MainTree">
+    <Sequence>
+        <BatteryOK/>
+        <SaySomething   message="mission started..." />
+        <MoveBase          goal="1;2;3"/>
+        <SaySomething   message="mission completed!" />
+    </Sequence>
+    </BehaviorTree>
+</root>
+"#;
+
+#[derive(Clone, Copy, Debug, FromString)]
+struct Pose2D {
+    x: f64,
+    y: f64,
+    theta: f64,
+}
+
+impl FromStr for Pose2D {
+    type Err = ParseFloatError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // remove redundant ' and &apos; from string
+        let s = value
+            .replace("'", "")
+            .trim()
+            .replace("&apos;", "")
+            .trim()
+            .to_string();
+        let v: Vec<&str> = s.split(';').collect();
+        let x = f64::from_string(v[0])?;
+        let y = f64::from_string(v[1])?;
+        let theta = f64::from_string(v[2])?;
+        Ok(Self { x, y, theta })
+    }
+}
+
+/// ConditionNode "BatteryOK"
+#[bt_node(SyncActionNode)]
+struct BatteryOK {}
+
+#[bt_node(SyncActionNode)]
+impl BatteryOK {
+    async fn tick(&mut self) -> NodeResult {
+        println!("battery is ok");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        PortsList::new()
+    }
+}
+
+/// SyncActionNode "SaySomething"
+#[bt_node(SyncActionNode)]
+struct SaySomething {}
+
+#[bt_node(SyncActionNode)]
+impl SaySomething {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("message")?;
+
+        println!("Robot says: {msg}");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("message", "hello"))
+    }
+}
+
+/// SyncActionNode "MoveBase"
+#[bt_node(StatefulActionNode)]
+struct MoveBase {
+    #[bt(default)]
+    counter: usize,
+}
+
+#[bt_node(StatefulActionNode)]
+impl MoveBase {
+    async fn on_start(&mut self) -> NodeResult {
+        let pos = node_.config.get_input::<Pose2D>("goal")?;
+
+        println!(
+            "[ MoveBase: SEND REQUEST ]. goal: x={:2.1} y={:2.1} theta={:2.1}",
+            pos.x, pos.y, pos.theta
+        );
+
+        Ok(NodeStatus::Running)
+    }
+
+    async fn on_running(&mut self) -> NodeResult {
+        if self.counter < 5 {
+            self.counter += 1;
+            println!("--- status: RUNNING");
+            Ok(NodeStatus::Running)
+        } else {
+            println!("[ MoveBase: FINISHED ]");
+            Ok(NodeStatus::Success)
+        }
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("goal"))
+    }
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register all needed nodes
+    register_action_node!(factory, "BatteryOK", BatteryOK);
+    register_action_node!(factory, "SaySomething", SaySomething);
+    register_action_node!(factory, "MoveBase", MoveBase);
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(XML.to_string(), &blackboard)?;
+
+    // run the BT using own loop with sleep to avoid busy loop
+    println!("--- ticking");
+    let mut result = tree.tick_once()?;
+    while result == NodeStatus::Running {
+        let _ = tokio::time::sleep(Duration::from_millis(100)).await;
+        println!("--- ticking");
+        result = tree.tick_once()?;
+    }
+
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/05_subtrees/main.rs
+++ b/behaviortree-rs/examples/05_subtrees/main.rs
@@ -1,0 +1,86 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the fifth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_05_subtrees
+//! It is enriched with random behavior of nodes
+//! - IsDoorClosed in main.rs
+//! - OpenDoor in subtree.rs
+//! - PickLock in subtree.rs
+//!
+
+mod subtree;
+
+use rand::Rng;
+use std::{fs::File, io::Read, path::PathBuf};
+
+use behaviortree_rs::prelude::*;
+
+/// ConditionNode "IsDoorClosed"
+#[bt_node(SyncActionNode)]
+struct IsDoorClosed {}
+
+#[bt_node(SyncActionNode)]
+impl IsDoorClosed {
+    async fn tick(&mut self) -> NodeResult {
+        let mut rng = rand::thread_rng();
+        let state = rng.gen::<bool>();
+        if state {
+            println!("door is closed");
+
+            Ok(NodeStatus::Success)
+        } else {
+            println!("door is open");
+
+            Ok(NodeStatus::Failure)
+        }
+    }
+}
+
+/// SyncActionNode "PassThroughDoor"
+#[bt_node(SyncActionNode)]
+struct PassThroughDoor {}
+
+#[bt_node(SyncActionNode)]
+impl PassThroughDoor {
+    async fn tick(&mut self) -> NodeResult {
+        println!("door passed");
+
+        Ok(NodeStatus::Success)
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register main tree nodes
+    register_action_node!(factory, "IsDoorClosed", IsDoorClosed);
+    register_action_node!(factory, "PassThroughDoor", PassThroughDoor);
+    // register subtrees nodes
+    subtree::register_nodes(&mut factory)?;
+
+    // construct path to examples xml independant of current directory in project
+    let mut directory = std::env::current_dir()?.to_str().unwrap().to_string();
+    let pos = directory.find("behaviortree-rs").expect("wrong path");
+    directory.replace_range(pos.., "behaviortree-rs");
+    let path = PathBuf::from(directory)
+        .join(file!())
+        .parent()
+        .expect("no path to file")
+        .join("subtrees.xml");
+
+    // read xml from file
+    let mut file = File::open(path)?;
+    let mut xml = String::new();
+    file.read_to_string(&mut xml)?;
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(xml, &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/05_subtrees/subtree.rs
+++ b/behaviortree-rs/examples/05_subtrees/subtree.rs
@@ -1,0 +1,75 @@
+// Copyright © 2024 Stephan Kunz
+
+//! Implementation of the subtree
+//!
+
+use behaviortree_rs::{nodes::decorator::RetryNode, prelude::*};
+use rand::Rng;
+
+/// SyncActionNode "OpenDoor"
+#[bt_node(SyncActionNode)]
+struct OpenDoor {}
+
+#[bt_node(SyncActionNode)]
+impl OpenDoor {
+    async fn tick(&mut self) -> NodeResult {
+        let mut rng = rand::thread_rng();
+        let state = rng.gen::<bool>();
+        if state {
+            println!("opened door");
+
+            Ok(NodeStatus::Success)
+        } else {
+            println!("could not open door");
+
+            Ok(NodeStatus::Failure)
+        }
+    }
+}
+
+/// SyncActionNode "PickLock"
+#[bt_node(SyncActionNode)]
+struct PickLock {}
+
+#[bt_node(SyncActionNode)]
+impl PickLock {
+    async fn tick(&mut self) -> NodeResult {
+        let mut rng = rand::thread_rng();
+        let state = rng.gen::<i32>();
+        if state % 5 == 0 {
+            println!("picked lock");
+
+            Ok(NodeStatus::Success)
+        } else {
+            println!("could not pick lock");
+
+            Ok(NodeStatus::Failure)
+        }
+    }
+}
+
+/// SyncActionNode "SmashDoor"
+#[bt_node(SyncActionNode)]
+struct SmashDoor {}
+
+#[bt_node(SyncActionNode)]
+impl SmashDoor {
+    async fn tick(&mut self) -> NodeResult {
+        println!("smashed door");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        PortsList::new()
+    }
+}
+
+pub fn register_nodes(factory: &mut Factory) -> anyhow::Result<()> {
+    register_action_node!(factory, "OpenDoor", OpenDoor);
+    register_decorator_node!(factory, "RetryUntilSuccessful", RetryNode);
+    register_action_node!(factory, "PickLock", PickLock);
+    register_action_node!(factory, "SmashDoor", SmashDoor);
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/05_subtrees/subtrees.xml
+++ b/behaviortree-rs/examples/05_subtrees/subtrees.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root BTCPP_format="4"
+      main_tree_to_execute="MainTree">
+  <BehaviorTree ID="DoorClosed">
+    <Fallback>
+      <OpenDoor/>
+      <RetryUntilSuccessful num_attempts="5">
+        <PickLock/>
+      </RetryUntilSuccessful>
+      <SmashDoor/>
+    </Fallback>
+  </BehaviorTree>
+
+  <BehaviorTree ID="MainTree">
+    <Sequence>
+      <Fallback>
+        <Inverter>
+          <IsDoorClosed/>
+        </Inverter>
+        <SubTree ID="DoorClosed"
+                 _autoremap="false"/>
+      </Fallback>
+      <PassThroughDoor/>
+    </Sequence>
+  </BehaviorTree>
+
+  <!-- Description of Node Models (used by Groot) -->
+  <TreeNodesModel>
+    <Condition ID="IsDoorClosed"
+               editable="true"/>
+    <Action ID="OpenDoor"
+            editable="true"/>
+    <Action ID="PassThroughDoor"
+            editable="true"/>
+    <Action ID="PickLock"
+            editable="true"/>
+    <Action ID="SmashDoor"
+            editable="true"/>
+  </TreeNodesModel>
+
+</root>

--- a/behaviortree-rs/examples/06_port_remapping/main.rs
+++ b/behaviortree-rs/examples/06_port_remapping/main.rs
@@ -1,7 +1,7 @@
 // Copyright © 2024 Stephan Kunz
 
-//! This example implements the fourteenth tutorial from https://www.behaviortree.dev
-//! see https://www.behaviortree.dev/docs/tutorial-advanced/tutorial_14_subtree_model
+//! This example implements the sixth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_06_subtree_ports
 //!
 //! Differences to BehaviorTree.CPP
 //! - there is no Script node available, that has to be implemented by user

--- a/behaviortree-rs/examples/06_port_remapping/main.rs
+++ b/behaviortree-rs/examples/06_port_remapping/main.rs
@@ -1,0 +1,113 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the fourteenth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-advanced/tutorial_14_subtree_model
+//!
+//! Differences to BehaviorTree.CPP
+//! - there is no Script node available, that has to be implemented by user
+//! - no access to sub blackboards
+//! - no 'Display' implementation for Blackboard
+//! - `Debug` implementation is basic
+
+mod move_robot;
+
+use std::{fs::File, io::Read, path::PathBuf};
+
+use behaviortree_rs::{basic_types::FromString, nodes::NodeError, prelude::*};
+
+/// SyncActionNode "Script"
+#[bt_node(SyncActionNode)]
+struct Script {}
+
+#[bt_node(SyncActionNode)]
+impl Script {
+    async fn tick(&mut self) -> NodeResult {
+        let script: String = node_.config.get_input("code")?;
+        let elements: Vec<&str> = script.split(":=").collect();
+        if elements[1].contains("{") {
+            let pos = move_robot::Position2D::from_string(elements[1].trim()).map_err(|_| {
+                NodeError::PortValueParseError("code".to_string(), "Position2D".to_string())
+            })?;
+            node_
+                .config
+                .blackboard()
+                .to_owned()
+                .set(elements[0].trim(), pos);
+        } else {
+            let mut content = elements[1].to_string();
+            // remove redundant ' from string
+            content = content.replace("'", "").trim().to_string();
+            // remove redundant &apos; from string
+            content = content.replace("&apos;", "").trim().to_string();
+            node_
+                .config
+                .blackboard()
+                .to_owned()
+                .set(elements[0].trim(), content);
+        }
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("code"))
+    }
+}
+
+/// SyncActionNode "SaySomething"
+#[bt_node(SyncActionNode)]
+struct SaySomething {}
+
+#[bt_node(SyncActionNode)]
+impl SaySomething {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("msg")?;
+
+        println!("Robot says: {msg}");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("msg", "hello"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register main tree nodes
+    register_action_node!(factory, "Script", Script);
+    register_action_node!(factory, "SaySomething", SaySomething);
+    // register subtrees nodes
+    move_robot::register_nodes(&mut factory)?;
+
+    // construct path to examples xml independant of current directory in project
+    let mut directory = std::env::current_dir()?.to_str().unwrap().to_string();
+    let pos = directory.find("behaviortree-rs").expect("wrong path");
+    directory.replace_range(pos.., "behaviortree-rs");
+    let path = PathBuf::from(directory)
+        .join(file!())
+        .parent()
+        .expect("no path to file")
+        .join("port_remapping.xml");
+
+    // read xml from file
+    let mut file = File::open(path)?;
+    let mut xml = String::new();
+    file.read_to_string(&mut xml)?;
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(xml, &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    // visualize some information about the final state of the blackboards
+    println!("{:?}", tree.root_blackboard());
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/06_port_remapping/move_robot.rs
+++ b/behaviortree-rs/examples/06_port_remapping/move_robot.rs
@@ -1,0 +1,77 @@
+// Copyright © 2024 Stephan Kunz
+
+//! Implementation of MoveRobot tree
+//!
+
+use std::{num::ParseFloatError, str::FromStr};
+
+use behaviortree_rs::{basic_types::FromString, prelude::*};
+use behaviortree_rs_derive::FromString;
+
+#[derive(Clone, Copy, Debug, FromString)]
+pub struct Position2D {
+    x: f64,
+    y: f64,
+    theta: f64,
+}
+
+impl FromStr for Position2D {
+    type Err = ParseFloatError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // remove redundant ' and &apos; from string
+        let s = value
+            .replace("'", "")
+            .trim()
+            .replace("&apos;", "")
+            .trim()
+            .to_string();
+        let v: Vec<&str> = s.split(';').collect();
+        let x = f64::from_string(v[0])?;
+        let y = f64::from_string(v[1])?;
+        let theta = f64::from_string(v[2])?;
+        Ok(Self { x, y, theta })
+    }
+}
+
+/// SyncActionNode "MoveBase"
+#[bt_node(StatefulActionNode)]
+struct MoveBase {
+    #[bt(default)]
+    counter: usize,
+}
+
+#[bt_node(StatefulActionNode)]
+impl MoveBase {
+    async fn on_start(&mut self) -> NodeResult {
+        let pos = node_.config.get_input::<Position2D>("goal")?;
+
+        println!(
+            "[ MoveBase: SEND REQUEST ]. goal: x={:2.1} y={:2.1} theta={:2.1}",
+            pos.x, pos.y, pos.theta
+        );
+
+        Ok(NodeStatus::Running)
+    }
+
+    async fn on_running(&mut self) -> NodeResult {
+        if self.counter < 5 {
+            self.counter += 1;
+            println!("--- status: RUNNING");
+            Ok(NodeStatus::Running)
+        } else {
+            println!("[ MoveBase: FINISHED ]");
+            Ok(NodeStatus::Success)
+        }
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("goal"))
+    }
+}
+
+pub fn register_nodes(factory: &mut Factory) -> anyhow::Result<()> {
+    register_action_node!(factory, "MoveBase", MoveBase);
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/06_port_remapping/port_remapping.xml
+++ b/behaviortree-rs/examples/06_port_remapping/port_remapping.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root BTCPP_format="4"
+      main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <Sequence>
+      <Script code="move_goal:=&apos;1;2;3&apos;"/>
+      <SubTree ID="MoveRobot"
+               target="{move_goal}"
+               result="{move_result}"/>
+      <SaySomething msg="{move_result}"/>
+    </Sequence>
+  </BehaviorTree>
+
+  <BehaviorTree ID="MoveRobot">
+    <Fallback>
+      <Sequence>
+        <MoveBase goal="{target}"/>
+        <Script code="result:=&apos;goal_reached&apos;"/>
+      </Sequence>
+      <ForceFailure>
+        <Script code="result:=&apos;error&apos;"/>
+      </ForceFailure>
+    </Fallback>
+  </BehaviorTree>
+
+  <!-- Description of Node Models (used by Groot) -->
+  <TreeNodesModel>
+    <Action ID="MoveBase"
+            editable="true">
+      <input_port name="goal"/>
+    </Action>
+    <Action ID="SaySomething"
+            editable="true">
+      <input_port name="msg"
+                  default="{move_result}"/>
+    </Action>
+  </TreeNodesModel>
+
+</root>

--- a/behaviortree-rs/examples/07_xml_files/main.rs
+++ b/behaviortree-rs/examples/07_xml_files/main.rs
@@ -1,0 +1,145 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the seventh tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_07_multiple_xml
+//!
+//! Via include gives an error.
+//! Manual loading works.
+
+use std::{fs::File, io::Read, path::PathBuf};
+
+use behaviortree_rs::prelude::*;
+
+const XML_MANUALLY: &str = r#"
+<root BTCPP_format="4"
+      main_tree_to_execute="MainTree">
+    <BehaviorTree ID="MainTree">
+        <Sequence>
+            <SaySomething message="starting MainTree" />
+            <SubTree ID="SubTreeA" />
+            <SubTree ID="SubTreeB" />
+        </Sequence>
+    </BehaviorTree>
+</root>
+"#;
+
+const XML_INCLUDE: &str = r#"
+<root BTCPP_format="4"
+      main_tree_to_execute="MainTree">
+    <include path="./subtree_A.xml" />
+    <include path="./subtree_B.xml" />
+    <BehaviorTree ID="MainTree">
+        <Sequence>
+            <SaySomething message="starting MainTree" />
+            <SubTree ID="SubTreeA" />
+            <SubTree ID="SubTreeB" />
+        </Sequence>
+    </BehaviorTree>
+</root>"#;
+
+/// SyncActionNode "SaySomething"
+#[bt_node(SyncActionNode)]
+struct SaySomething {}
+
+#[bt_node(SyncActionNode)]
+impl SaySomething {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("message")?;
+
+        println!("Robot says: {msg}");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("message"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // via include
+    {
+        println!("subtrees via include");
+        /*
+        fails with
+        Error: Errors like this shouldn't happen. Something bad has happened. Please report this. Empty(BytesStart { buf: Borrowed("include path=\"./subtree_A.xml\" "), name_len: 7 })
+        */
+        // create BT environment
+        let mut factory = Factory::new();
+        let blackboard = Blackboard::create();
+
+        // register all needed nodes
+        register_action_node!(factory, "SaySomething", SaySomething);
+
+        // create tree
+        let tree = factory.create_sync_tree_from_text(XML_INCLUDE.to_string(), &blackboard);
+        match tree {
+            Ok(mut tree) => {
+                // run the BT
+                let result = tree.tick_while_running()?;
+                println!("tree result is {result}");
+            }
+            Err(error) => println!("{error}"),
+        }
+    }
+
+    // manually
+    {
+        println!("subtrees manually");
+
+        // create BT environment
+        let mut factory = Factory::new();
+        let blackboard = Blackboard::create();
+
+        // register all needed nodes
+        register_action_node!(factory, "SaySomething", SaySomething);
+
+        // create tree
+        // create the search path to xml filess independant of current directory in project
+        let mut directory = std::env::current_dir()?.to_str().unwrap().to_string();
+        let pos = directory.find("behaviortree-rs").expect("wrong path");
+        directory.replace_range(pos.., "behaviortree-rs");
+        let search_path = PathBuf::from(directory)
+            .join(file!())
+            .parent()
+            .expect("no path to file")
+            .to_string_lossy()
+            .to_string();
+
+        // iterate over directories xml files
+        let files = std::fs::read_dir(search_path)?.flatten();
+        for file in files {
+            if file
+                .file_name()
+                .into_string()
+                .expect("could not determine file type")
+                .ends_with("xml")
+            {
+                // read xml from file
+                let mut file = File::open(file.path())?;
+                let mut xml = String::new();
+                file.read_to_string(&mut xml)?;
+                // register
+                factory.register_bt_from_text(xml)?;
+            }
+        }
+
+        //// register main tree
+        //factory.register_bt_from_text(XML_MANUALLY.into())?;
+        //// instantiate the BT
+        //let tree = factory.instantiate_sync_tree(&blackboard, "MainTree");
+
+        // create the BT
+        let tree = factory.create_sync_tree_from_text(XML_MANUALLY.to_string(), &blackboard);
+        match tree {
+            Ok(mut tree) => {
+                // run the BT
+                let result = tree.tick_while_running()?;
+                println!("tree result is {result}");
+            }
+            Err(error) => println!("{error}"),
+        }
+    }
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/07_xml_files/subtree_A.xml
+++ b/behaviortree-rs/examples/07_xml_files/subtree_A.xml
@@ -1,0 +1,5 @@
+<root>
+    <BehaviorTree ID="SubTreeA">
+        <SaySomething message="Executing Sub_A" />
+    </BehaviorTree>
+</root>

--- a/behaviortree-rs/examples/07_xml_files/subtree_B.xml
+++ b/behaviortree-rs/examples/07_xml_files/subtree_B.xml
@@ -1,0 +1,5 @@
+<root>
+    <BehaviorTree ID="SubTreeB">
+        <SaySomething message="Executing Sub_B" />
+    </BehaviorTree>
+</root>

--- a/behaviortree-rs/examples/08_arguments/main.rs
+++ b/behaviortree-rs/examples/08_arguments/main.rs
@@ -1,0 +1,141 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the eigth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_08_additional_args
+//!
+//! Differences to BehaviorTree.CPP
+//! - using an initialize method currently is not possible because we can not get a mutuable iterator.
+//!   A method visit_nodes_mut() is missing.
+//!
+
+use behaviortree_rs::prelude::*;
+
+const XML: &str = r#"
+<root BTCPP_format="4">
+    <BehaviorTree ID="MainTree">
+        <Sequence>
+            <ActionA message="Running ActionA" />
+            <ActionB message="Running ActionB" />
+            <ActionC message="Running ActionC" />
+        </Sequence>
+    </BehaviorTree>
+</root>"#;
+
+/// SyncActionNode "ActionA"
+#[bt_node(SyncActionNode)]
+struct ActionA {
+    arg1: i32,
+    arg2: String,
+}
+
+#[bt_node(SyncActionNode)]
+impl ActionA {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("message")?;
+
+        let arg1 = self.arg1;
+        let arg2 = self.arg2.clone();
+        println!("{msg} robot says: {}, the answer is {}!", arg2, arg1);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("message"))
+    }
+}
+
+/// SyncActionNode "ActionB"
+#[bt_node(SyncActionNode)]
+struct ActionB {
+    #[bt(default)]
+    arg1: i32,
+    #[bt(default)]
+    arg2: String,
+}
+
+#[bt_node(SyncActionNode)]
+impl ActionB {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("message")?;
+
+        println!("{msg} is currently not implementable");
+        //let arg1 = self.arg1;
+        //let arg2 = self.arg2.clone();
+        //println!("{msg} robot says: {}, the answer is {}!", arg2, arg1);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("message"))
+    }
+
+    #[allow(dead_code)]
+    fn initialize(&mut self, arg1: i32, arg2: String) {
+        self.arg1 = arg1;
+        self.arg2 = arg2;
+    }
+}
+
+/// SyncActionNode "ActionC"
+#[bt_node(SyncActionNode)]
+struct ActionC {
+    #[bt(default = "42")]
+    arg1: i32,
+    #[bt(default = "String::from(\"hello world\")")]
+    arg2: String,
+}
+
+#[bt_node(SyncActionNode)]
+impl ActionC {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("message")?;
+
+        let arg1 = self.arg1;
+        let arg2 = self.arg2.clone();
+        println!("{msg} robot says: {}, the answer is {}!", arg2, arg1);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("message"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    let arg1 = 42;
+    let arg2 = String::from("hello world");
+
+    // registering with a different constructor
+    register_action_node!(factory, "ActionA", ActionA, arg1, arg2);
+    // registering for using initialize function
+    register_action_node!(factory, "ActionB", ActionB);
+    // registering using defaults
+    register_action_node!(factory, "ActionC", ActionC);
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(XML.to_string(), &blackboard)?;
+
+    // initialize ActionB with the help of a visitor
+    /*
+    currently does not work, as there is no visit_nodes_mut() method providing a mutuable iterator
+    for node in tree.visit_nodes_mut() {
+        if node.name() == "ActionB" {
+            let action = node.context.downcast_mut::<ActionB>().unwrap();
+            action.initialize(42, "hello world".into());
+        }
+    }
+    */
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/09_scripting/main.rs
+++ b/behaviortree-rs/examples/09_scripting/main.rs
@@ -1,0 +1,15 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the nineth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_09_scripting
+//!
+
+use behaviortree_rs::prelude::*;
+
+fn main() -> anyhow::Result<()> {
+    let result = NodeStatus::Success;
+    println!("not yet implemented");
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/10_observer/main.rs
+++ b/behaviortree-rs/examples/10_observer/main.rs
@@ -1,0 +1,53 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the tenth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_10_observer
+//!
+//! Currently not implementable due to same problem as in example 07_xml_files
+
+use behaviortree_rs::prelude::*;
+
+const XML: &str = r#"
+<root BTCPP_format="4"
+    main_tree_to_execute="MainTree">
+    <BehaviorTree ID="MainTree">
+        <Sequence>
+            <Fallback>
+                <AlwaysFailure name="failing_action"/>
+                <SubTree ID="SubTreeA" name="mysub"/>
+            </Fallback>
+            <AlwaysSuccess name="last_action"/>
+        </Sequence>
+    </BehaviorTree>
+
+    <BehaviorTree ID="SubTreeA">
+        <Sequence>
+            <AlwaysSuccess name="action_subA"/>
+            <SubTree ID="SubTreeB" name="sub_nested"/>
+            <SubTree ID="SubTreeB" />
+        </Sequence>
+    </BehaviorTree>
+
+    <BehaviorTree ID="SubTreeB">
+        <AlwaysSuccess name="action_subB"/>
+    </BehaviorTree>
+</root>
+"#;
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // create the BT
+    /* create tree fails at line 789 in trees.rs with
+    Error: Violated node type constraint: Expected end tag for BehaviorTree
+    */
+    let mut tree = factory.create_sync_tree_from_text(XML.to_string(), &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/11_groot2/main.rs
+++ b/behaviortree-rs/examples/11_groot2/main.rs
@@ -1,0 +1,15 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the eleventh tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_11_groot2
+//!
+
+use behaviortree_rs::prelude::*;
+
+fn main() -> anyhow::Result<()> {
+    let result = NodeStatus::Success;
+    println!("not yet implemented");
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/12_port_defaults/main.rs
+++ b/behaviortree-rs/examples/12_port_defaults/main.rs
@@ -1,0 +1,130 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the twelvth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-advanced/tutorial_12_default_ports
+//!
+//! Differences to BehaviorTree.CPP
+//! - It is not possible to add an action node directly below the root node
+//! - only 3 of the 6 ways in BehaviorTree.CPP are working in an easy manner
+//!
+
+use std::{
+    fmt::{Display, Formatter},
+    num::ParseIntError,
+    str::FromStr,
+};
+
+use behaviortree_rs::{basic_types::FromString, nodes::NodeError, prelude::*};
+use behaviortree_rs_derive::{BTToString, FromString};
+
+const XML: &str = r#"
+<root BTCPP_format="4">
+    <BehaviorTree ID="MainTree">
+        <Sequence>
+            <NodeWithDefaultPoints input="-1,-2"/>
+        </Sequence>
+    </BehaviorTree>
+</root>"#;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, BTToString, FromString)]
+struct Point2D {
+    x: i32,
+    y: i32,
+}
+
+impl Display for Point2D {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{},{}", self.x, self.y)
+    }
+}
+
+impl FromStr for Point2D {
+    type Err = ParseIntError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // remove redundant ' and &apos; from string
+        let s = value
+            .replace("'", "")
+            .trim()
+            .replace("&apos;", "")
+            .trim()
+            .to_string();
+        let v: Vec<&str> = s.split(',').collect();
+        let x = i32::from_string(v[0])?;
+        let y = i32::from_string(v[1])?;
+        Ok(Self { x, y })
+    }
+}
+
+/// SyncActionNode "CalculateGoal"
+#[bt_node(SyncActionNode)]
+struct NodeWithDefaultPoints {}
+
+#[bt_node(SyncActionNode)]
+impl NodeWithDefaultPoints {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("input")?;
+        let point = Point2D::from_string(&msg)
+            .map_err(|_| NodeError::PortValueParseError("input".into(), msg))?;
+        println!("input:  [{},{}]", point.x, point.y);
+
+        let msg: String = node_.config.get_input("pointA")?;
+        let point = Point2D::from_string(&msg)
+            .map_err(|_| NodeError::PortValueParseError("pointA".into(), msg))?;
+        println!("pointA:  [{},{}]", point.x, point.y);
+
+        //let msg: String = node_.config.get_input("pointB")?;
+        //let point = Point2D::from_string(&msg).map_err(|_| NodeError::PortValueParseError("pointB".into(), msg))?;
+        //println!("pointB:  [{},{}]", point.x, point.y);
+
+        let msg: String = node_.config.get_input("pointC")?;
+        let point = Point2D::from_string(&msg)
+            .map_err(|_| NodeError::PortValueParseError("pointC".into(), msg))?;
+        println!("pointC:  [{},{}]", point.x, point.y);
+
+        //let msg: String = node_.config.get_input("pointD")?;
+        //let point = Point2D::from_string(&msg).map_err(|_| NodeError::PortValueParseError("pointD".into(), msg))?;
+        //println!("pointD:  [{},{}]", point.x, point.y);
+
+        //let msg: String = node_.config.get_input("pointE")?;
+        //let point = Point2D::from_string(&msg).map_err(|_| NodeError::PortValueParseError("pointE".into(), msg))?;
+        //println!("pointE:  [{},{}]", point.x, point.y);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        let json = r#"(json:{"x':9,"y":10})"#;
+        define_ports!(
+            input_port!("input"),                          // no default value
+            input_port!("pointA", Point2D { x: 1, y: 2 }), // default value is [1,2]
+            input_port!("pointB", "{point}"), // default value inside blackboard {point}
+            input_port!("pointC", "5,6"),     // default value is [5,6],
+            input_port!("pointD", "{=}"),     // default value inside blackboard {pointD}
+            input_port!("pointE", json)       // default value inside blackboard {pointD}
+                                              //input_port!("pointE, r#"(json:{"x':9,"y":10})"#) // default value is [9,10]
+        )
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register all needed nodes
+    register_action_node!(factory, "NodeWithDefaultPoints", NodeWithDefaultPoints);
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(XML.to_string(), &blackboard)?;
+
+    // initialize blackboard values
+    tree.root_blackboard().set("point", Point2D { x: 3, y: 4 });
+    tree.root_blackboard().set("pointD", Point2D { x: 7, y: 8 });
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/13_port_by_reference/main.rs
+++ b/behaviortree-rs/examples/13_port_by_reference/main.rs
@@ -1,0 +1,106 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the thirteenth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-advanced/tutorial_13_blackboard_reference
+//!
+//! Differences to BehaviorTree.CPP
+//! - example at behaviorTree.CPP is inconsistent, does not match code in github repo
+//! - could not get the get_exact::<wanted_type>() access to work
+//!
+
+use behaviortree_rs::{nodes::NodeError, prelude::*};
+
+const XML: &str = r#"
+<root BTCPP_format="4"
+      main_tree_to_execute="SegmentCup">
+    <BehaviorTree ID="SegmentCup">
+       <Sequence>
+           <AcquirePointCloud  cloud="{pointcloud}"/>
+           <SegmentObject  obj_name="cup" cloud="{pointcloud}" obj_pose="{pose}"/>
+       </Sequence>
+    </BehaviorTree>
+</root>"#;
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct Point {
+    x: i32,
+    y: i32,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+struct PointCloud {
+    points: Vec<Point>,
+}
+
+/// ActionNode "AcquirePointCloud"
+#[bt_node(SyncActionNode)]
+struct AcquirePointCloud {}
+
+#[bt_node(SyncActionNode)]
+impl AcquirePointCloud {
+    async fn tick(&mut self) -> NodeResult {
+        println!("setting PointCloud");
+        // put a PointCloud into blackboard
+        let p_cloud = vec![
+            Point { x: 0, y: 0 },
+            Point { x: 1, y: 1 },
+            Point { x: 2, y: 2 },
+            Point { x: 3, y: 3 },
+        ];
+        node_.config.blackboard.set("cloud", p_cloud);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(output_port!("cloud"))
+    }
+}
+
+/// ActionNode "SegmentObject"
+#[bt_node(SyncActionNode)]
+struct SegmentObject {}
+
+#[bt_node(SyncActionNode)]
+impl SegmentObject {
+    async fn tick(&mut self) -> NodeResult {
+        println!("accessing PointCloud");
+        let p_cloud = node_
+            .config
+            .blackboard
+            .get_exact::<&PointCloud>("cloud")
+            .ok_or_else(|| NodeError::PortError("cloud".into()))?;
+        println!("PointCloud is {:#?}", p_cloud);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(
+            input_port!("cloud"),
+            input_port!("obj_name"),
+            output_port!("obj_pose")
+        )
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register all needed nodes
+    register_action_node!(factory, "AcquirePointCloud", AcquirePointCloud);
+    register_action_node!(factory, "SegmentObject", SegmentObject);
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(XML.to_string(), &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/14_autoremap/autoremap.xml
+++ b/behaviortree-rs/examples/14_autoremap/autoremap.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<root BTCPP_format="4"
+      main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <Sequence>
+      <Script code="target:=&apos;1;2;3&apos;"/>
+      <SubTree ID="MoveRobot"
+               _autoremap="true"
+               frame="world"/>
+      <SaySomething msg="{result}"/>
+    </Sequence>
+  </BehaviorTree>
+
+  <BehaviorTree ID="MoveRobot">
+    <Fallback>
+      <Sequence>
+        <MoveBase goal="{target}"/>
+        <Script code="result:=&apos;goal_reached&apos;"/>
+      </Sequence>
+      <ForceFailure>
+        <Script code="result:=&apos;error&apos;"/>
+      </ForceFailure>
+    </Fallback>
+  </BehaviorTree>
+
+  <!-- Description of Node Models (used by Groot) -->
+  <TreeNodesModel>
+    <Action ID="MoveBase"
+            editable="true">
+      <input_port name="goal"/>
+    </Action>
+    <Action ID="SaySomething"
+            editable="true">
+      <input_port name="msg"/>
+    </Action>
+  </TreeNodesModel>
+
+</root>

--- a/behaviortree-rs/examples/14_autoremap/main.rs
+++ b/behaviortree-rs/examples/14_autoremap/main.rs
@@ -1,7 +1,7 @@
 // Copyright © 2024 Stephan Kunz
 
-//! This example implements the sixth tutorial from https://www.behaviortree.dev
-//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_06_subtree_ports
+//! This example implements the fourteenth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-advanced/tutorial_14_subtree_model
 //!
 //! Differences to BehaviorTree.CPP
 //! - there is no Script node available, that has to be implemented by user

--- a/behaviortree-rs/examples/14_autoremap/main.rs
+++ b/behaviortree-rs/examples/14_autoremap/main.rs
@@ -1,0 +1,110 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the sixth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-basics/tutorial_06_subtree_ports
+//!
+//! Differences to BehaviorTree.CPP
+//! - there is no Script node available, that has to be implemented by user
+//! - example in BehaviorTree.CPP is inconsistent
+//! - not sure wether this example really shows how to do it
+//!
+
+mod move_robot;
+
+use std::{fs::File, io::Read, path::PathBuf};
+
+use behaviortree_rs::{basic_types::FromString, nodes::NodeError, prelude::*};
+
+/// SyncActionNode "Script"
+#[bt_node(SyncActionNode)]
+struct Script {}
+
+#[bt_node(SyncActionNode)]
+impl Script {
+    async fn tick(&mut self) -> NodeResult {
+        let script: String = node_.config.get_input("code")?;
+        let elements: Vec<&str> = script.split(":=").collect();
+        if elements[1].contains("{") {
+            let pos = move_robot::Position2D::from_string(elements[1].trim()).map_err(|_| {
+                NodeError::PortValueParseError("code".to_string(), "Position2D".to_string())
+            })?;
+            node_
+                .config
+                .blackboard()
+                .to_owned()
+                .set(elements[0].trim(), pos);
+        } else {
+            let mut content = elements[1].to_string();
+            // remove redundant ' from string
+            content = content.replace("'", "").trim().to_string();
+            // remove redundant &apos; from string
+            content = content.replace("&apos;", "").trim().to_string();
+            node_
+                .config
+                .blackboard()
+                .to_owned()
+                .set(elements[0].trim(), content);
+        }
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("code"))
+    }
+}
+
+/// SyncActionNode "SaySomething"
+#[bt_node(SyncActionNode)]
+struct SaySomething {}
+
+#[bt_node(SyncActionNode)]
+impl SaySomething {
+    async fn tick(&mut self) -> NodeResult {
+        let msg: String = node_.config.get_input("msg")?;
+
+        println!("Robot says: {msg}");
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("msg", "hello"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create BT environment
+    let mut factory = Factory::new();
+    let blackboard = Blackboard::create();
+
+    // register main tree nodes
+    register_action_node!(factory, "Script", Script);
+    register_action_node!(factory, "SaySomething", SaySomething);
+    // register subtrees nodes
+    move_robot::register_nodes(&mut factory)?;
+
+    // construct path to examples xml independant of current directory in project
+    let mut directory = std::env::current_dir()?.to_str().unwrap().to_string();
+    let pos = directory.find("behaviortree-rs").expect("wrong path");
+    directory.replace_range(pos.., "behaviortree-rs");
+    let path = PathBuf::from(directory)
+        .join(file!())
+        .parent()
+        .expect("no path to file")
+        .join("autoremap.xml");
+
+    // read xml from file
+    let mut file = File::open(path)?;
+    let mut xml = String::new();
+    file.read_to_string(&mut xml)?;
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(xml, &blackboard)?;
+
+    // run the BT
+    let result = tree.tick_while_running()?;
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/14_autoremap/move_robot.rs
+++ b/behaviortree-rs/examples/14_autoremap/move_robot.rs
@@ -1,0 +1,77 @@
+// Copyright © 2024 Stephan Kunz
+
+//! Implementation of MoveRobot tree
+//!
+
+use std::{num::ParseFloatError, str::FromStr};
+
+use behaviortree_rs::{basic_types::FromString, prelude::*};
+use behaviortree_rs_derive::FromString;
+
+#[derive(Clone, Copy, Debug, FromString)]
+pub struct Position2D {
+    x: f64,
+    y: f64,
+    theta: f64,
+}
+
+impl FromStr for Position2D {
+    type Err = ParseFloatError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        // remove redundant ' and &apos; from string
+        let s = value
+            .replace("'", "")
+            .trim()
+            .replace("&apos;", "")
+            .trim()
+            .to_string();
+        let v: Vec<&str> = s.split(';').collect();
+        let x = f64::from_string(v[0])?;
+        let y = f64::from_string(v[1])?;
+        let theta = f64::from_string(v[2])?;
+        Ok(Self { x, y, theta })
+    }
+}
+
+/// SyncActionNode "MoveBase"
+#[bt_node(StatefulActionNode)]
+struct MoveBase {
+    #[bt(default)]
+    counter: usize,
+}
+
+#[bt_node(StatefulActionNode)]
+impl MoveBase {
+    async fn on_start(&mut self) -> NodeResult {
+        let pos = node_.config.get_input::<Position2D>("goal")?;
+
+        println!(
+            "[ MoveBase: SEND REQUEST ]. goal: x={:2.1} y={:2.1} theta={:2.1}",
+            pos.x, pos.y, pos.theta
+        );
+
+        Ok(NodeStatus::Running)
+    }
+
+    async fn on_running(&mut self) -> NodeResult {
+        if self.counter < 5 {
+            self.counter += 1;
+            println!("--- status: RUNNING");
+            Ok(NodeStatus::Running)
+        } else {
+            println!("[ MoveBase: FINISHED ]");
+            Ok(NodeStatus::Success)
+        }
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("goal"))
+    }
+}
+
+pub fn register_nodes(factory: &mut Factory) -> anyhow::Result<()> {
+    register_action_node!(factory, "MoveBase", MoveBase);
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/15_mocking_replacement/main.rs
+++ b/behaviortree-rs/examples/15_mocking_replacement/main.rs
@@ -1,0 +1,15 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the fifteenth tutorial from https://www.behaviortree.dev
+//! see https://www.behaviortree.dev/docs/tutorial-advanced/tutorial_15_replace_rules
+//!
+
+use behaviortree_rs::prelude::*;
+
+fn main() -> anyhow::Result<()> {
+    let result = NodeStatus::Success;
+    println!("not yet implemented");
+    println!("tree result is {result}");
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/16_global_blackboard/main.rs
+++ b/behaviortree-rs/examples/16_global_blackboard/main.rs
@@ -1,0 +1,140 @@
+// Copyright © 2024 Stephan Kunz
+
+//! This example implements the sixteenth tutorial from https://www.behaviortree.dev
+//! https://www.behaviortree.dev/docs/tutorial-advanced/tutorial_16_global_blackboard
+//!
+//! Differences to BehaviorTree.CPP
+//! - currently not working due to missing functionality
+//! 
+
+use behaviortree_rs::{nodes::NodeError, prelude::*};
+
+const XML: &str = r#"
+<root BTCPP_format="4"
+      main_tree_to_execute="MainTree">
+    <BehaviorTree ID="MainTree">
+        <Sequence>
+            <PrintNumber name="main_print" val="{@value}" />
+            <SubTree ID="MySub"/>
+        </Sequence>
+    </BehaviorTree>
+
+    <BehaviorTree ID="MySub">
+        <Sequence>
+            <PrintNumber name="sub_print" val="{@value}" />
+            <SubTree ID="MySubSub"/>
+            <Script code="@value_sqr := @value * @value" />
+        </Sequence>
+    </BehaviorTree>
+
+    <BehaviorTree ID="MySubSub">
+        <Sequence>
+            <PrintNumber name="sub_sub_print" val="{@value}" />
+            <Script code="@value_pow3 := @value * @value * @value" />
+            <SubTree ID="MySubSubSub"/>
+        </Sequence>
+    </BehaviorTree>
+
+    <BehaviorTree ID="MySubSubSub">
+        <Sequence>
+            <PrintNumber name="sub_sub_sub_print" val="{@value}" />
+            <Script code="@value_pow4 := @value * @value * @value * @value" />
+        </Sequence>
+    </BehaviorTree>
+</root>"#;
+
+/// ActionNode "PrintNumber"
+#[bt_node(SyncActionNode)]
+struct PrintNumber {}
+
+#[bt_node(SyncActionNode)]
+impl PrintNumber {
+    async fn tick(&mut self) -> NodeResult {
+        let name: String = node_.config.get_input("name")?;
+        println!("PrintNumber {}", name);
+        let value: i32 = node_.config.get_input("val")?;
+
+        println!("[{}] val: {}", name, value);
+
+        Ok(NodeStatus::Success)
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("name"), input_port!("val"))
+    }
+}
+
+/// SyncActionNode "Script"
+#[bt_node(SyncActionNode)]
+struct Script {}
+
+#[bt_node(SyncActionNode)]
+impl Script {
+    async fn tick(&mut self) -> NodeResult {
+        print!("Script: ");
+        let script: String = node_.config.get_input("code")?;
+        let elements: Vec<&str> = script.split(":=").collect();
+        //println!("{} - {}", elements[0], elements[1]);
+
+        // try to cheat, as there is no script language implemented
+        let value: i32 = node_
+            .config
+            .blackboard
+            .get("@value")
+            .ok_or_else(|| NodeError::PortError("@value".into()))?;
+        if  elements[0].contains("value_sqr") {
+            println!("sqr");
+            node_.config.blackboard.set("@value_sqr", value * value);
+            Ok(NodeStatus::Success)
+        } else if  elements[0].contains("value_pow3") {
+            println!("pow3");
+            node_.config.blackboard.set("@value_pow3", value * value * value);
+            Ok(NodeStatus::Success)
+        } else if  elements[0].contains("value_pow4") {
+            println!("pow4");
+            node_.config.blackboard.set("@value_pow4", value * value * value * value);
+            Ok(NodeStatus::Success)
+        } else {
+            Ok(NodeStatus::Failure)
+        }
+    }
+
+    fn ports() -> PortsList {
+        define_ports!(input_port!("code"))
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    // create an external blackboard which will survive the tree
+    let mut global_blackboard = Blackboard::create();
+
+    // create BT environment
+    let mut factory = Factory::new();
+    // BT-Trees blackboard has global blackboard as parent
+    let blackboard = Blackboard::with_parent(&global_blackboard);
+
+    // register all needed nodes
+    register_action_node!(factory, "PrintNumber", PrintNumber);
+    register_action_node!(factory, "Script", Script);
+
+    // create the BT
+    let mut tree = factory.create_sync_tree_from_text(XML.into(), &blackboard)?;
+
+    // direct interaction with the global blackboard
+    for value in 1..=3 {
+        global_blackboard.set("value", value);
+        tree.tick_once()?;
+        let value_sqr = global_blackboard
+            .get::<i32>("value_sqr")
+            .ok_or_else(|| NodeError::PortError("value_sqr".into()))?;
+        let value_pow3 = global_blackboard
+            .get::<i32>("value_pow3")
+            .ok_or_else(|| NodeError::PortError("value_pow3".into()))?;
+        let value_pow4 = global_blackboard
+            .get::<i32>("value_pow4")
+            .ok_or_else(|| NodeError::PortError("value_pow3".into()))?;
+        println!("[While loop] value: {value} value_sqr: {value_sqr} value_pow3: {value_pow3} value_pow4: {value_pow4}");
+    }
+
+    Ok(())
+}

--- a/behaviortree-rs/examples/README.md
+++ b/behaviortree-rs/examples/README.md
@@ -1,0 +1,178 @@
+# Examples for behaviortree-rs
+
+These examples follow the tutorial of [BehaviorTree.dev](https://www.behaviortree.dev/docs/intro).
+
+## [A first behaviortree](01_first/main.rs)
+
+This example implements the [first tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_01_first_tree)
+
+Run it with ```cargo run --example 01_first```
+
+Differences to BehaviorTree.CPP:
+
+- we cannot register functions/methods of a struct/class
+- there is no separate ConditionNode type, these have to be implemented as SyncActionNode
+- we do not have a nice function to read xml definitions from a file
+
+## [Blackboard and ports](02_ports/main.rs)
+
+This example implements the [second tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_02_basic_ports)
+
+Run it with ```cargo run --example 02_ports```
+
+Differences to BehaviorTree.CPP
+
+- we do not have a nice function to read xml definitions from a file
+
+## [Use generic types with ports](03_ports_generic/main.rs)
+
+This example implements the [third tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_03_generic_ports)
+
+Run it with ```cargo run --example 03_ports_generic```
+
+Differences to BehaviorTree.CPP
+
+- there is no Script node available, that has to be implemented by user
+
+## [Create reactive behavior](04_reactive/main.rs)
+
+This example implements the [fourth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_04_sequence)
+
+Run it with ```cargo run --example 04_reactive```
+
+Differences to BehaviorTree.CPP
+
+- there is no tree::sleep(...) available, using sleep of tokio async runtime instead, which is not interrupted when tree state changes
+
+## [Use of subtrees](05_subtrees/main.rs)
+
+This example implements the [fifth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_05_subtrees)
+
+Run it with ```cargo run --example 05_subtrees```
+
+Differences to BehaviorTree.CPP
+
+- we do not have a nice function to read xml definitions from a file
+
+It is enriched with random behavior of nodes, so run it several times to see different executions
+
+- IsDoorClosed in [main.rs](05_subtrees/main.rs)
+- OpenDoor in [subtree.rs](05_subtrees/subtree.rs)
+- PickLock in [subtree.rs](05_subtrees/subtree.rs)
+
+## [Remapping of ports](06_port_remapping/main.rs)
+
+This example implements the [sixth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_06_subtree_ports)
+
+Run it with ```cargo run --example 06_port_remapping```
+
+Differences to BehaviorTree.CPP
+
+- there is no Script node available, that has to be implemented by user
+- no access to sub blackboards
+- no 'Display' implementation for Blackboard
+- `Debug` implementation is basic
+
+## [Use multiple xml files](07_xml_files/main.rs)
+
+This example implements the [seventh tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_07_multiple_xml)
+
+Run it with ```cargo run --example 07_xml_files```
+
+Via include gives
+
+```text
+Error: Errors like this shouldn't happen. Something bad has happened. Please report this. Empty(BytesStart { buf: Borrowed("include path=\"./subtree_A.xml\" "), name_len: 7 })
+```
+
+Manual loading works
+
+## [Pass arguments to nodes](08_arguments/main.rs)
+
+This example implements the [eighth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_08_additional_args)
+
+Run it with ```cargo run --example 08_arguments```
+
+Differences to BehaviorTree.CPP
+
+- using an initialize method currently is not possible, a method visit_nodes_mut() is missing
+
+
+## [Scripting](09_scripting/main.rs)
+
+This example implements the [nineth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_09_scripting)
+
+Run it with ```cargo run --example 09_scripting```
+
+Currently not implemented as there is no scripting node in the library
+
+## [Logging and observer](10_observer/main.rs)
+
+This example implements the [tenth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_10_observer)
+
+Run it with ```cargo run --example 10_observer```
+
+Currently not implementable due to same problem in tree.rs as in 07_xml_files
+
+## [Connection to groot2](11_groot2/main.rs)
+
+This example implements the [eleventh tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_11_groot2)
+
+Run it with ```cargo run --example 11_groot2```
+
+Currently not implementable due to missing functionality
+
+## [Default values for ports](12_port_defaults/main.rs)
+
+This example implements the [twelveth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_12_default_ports)
+
+Run it with ```cargo run --example 12_port_defaults```
+
+Differences to BehaviorTree.CPP
+
+- It is not possible to add an action node directly below the root node (same error as in 07_xml_files and 10_observer)
+- only 3 of the 6 ways in BehaviorTree.CPP are working (at least in an easy manner)
+
+## [Access ports by reference](13_port_by_reference/main.rs)
+
+This example implements the [thirteenth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_13_blackboard_reference)
+
+Run it with ```cargo run --example 13_port_by_reference```
+
+Not working
+
+Differences to BehaviorTree.CPP
+- example at behaviorTree.CPP is inconsistent, does not match code in github repo
+- could not get the ```blackboard.get_exact::<wanted_type>()``` access to work
+
+## [Subtree models and autoremap](14_autoremap/main.rs)
+
+This example implements the [fourteenth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_14_subtree_model)
+
+Run it with ```cargo run --example 14_autoremap```
+
+Differences to BehaviorTree.CPP
+
+- example in BehaviorTree.CPP is inconsistent
+- not sure wether this example really shows how to do it
+
+## [Mocking and replacement of nodes](15_mocking_replacement/main.rs)
+
+This example implements the [fifteenth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_15_replace_rules)
+
+Run it with ```cargo run --example 15_mocking_replacement```
+
+Currently not implementable due to missing functionality
+
+## [Usage of a global blackboard](16_global_blackboard/main.rs)
+
+This example implements the [sixteenth tutorial from BehaviorTree.dev](https://www.behaviortree.dev/docs/tutorial-basics/tutorial_16_global_blackboard)
+
+Run it with ```cargo run --example 16_global_blackboard```
+
+Currently not working due to missing functionality
+
+Differences to BehaviorTree.CPP
+
+- there is no Script node available, that has to be implemented by user
+- enhanced example for trees with depth > 2 level


### PR DESCRIPTION
Implementation draft of the tutorial examples from [behaviortree.dev.](https://www.behaviortree.dev/).

Not all of them are working yet. See README.md in examples folder.

Enhanced Cargo.toml to exclude the examples on `crates.io` and usage of crate `rand` for the examples.